### PR TITLE
feat: 문제 출제 페이지

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -15,6 +15,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.3.2",
+    "nanoid": "^3.1.30",
     "prettier": "^2.4.1",
     "react": "^17.0.2",
     "react-ace": "^9.5.0",

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -7,6 +7,10 @@ body {
   background-color: #282c2f;
 }
 
+* {
+  box-sizing: border-box;
+}
+
 div,
 button {
   font-family: inherit;

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,22 +1,17 @@
-import React, { useState, useCallback } from 'react';
-import {
-  BrowserRouter,
-  Switch,
-  Route,
-  Link,
-  Redirect,
-  useHistory,
-} from 'react-router-dom';
+import React, { useCallback } from 'react';
+import { BrowserRouter, Switch, Route, Link, Redirect } from 'react-router-dom';
+import { useLogin } from 'hooks/useLogin';
 import './App.css';
 
 import styled from '@cyfm/styled';
-import logo from './assets/images/upscale.png';
+import logo from 'assets/images/upscale.png';
 
-import ListPage from './pages/ListPage';
-import LoginPage from './pages/LoginPage';
-import DebugPage from './pages/DebugPage';
-import WritePage from './pages/WritePage';
-import TopNavLink from './components/TopNavLink';
+import ListPage from 'pages/ListPage';
+import LoginPage from 'pages/LoginPage';
+import DebugPage from 'pages/DebugPage';
+import WritePage from 'pages/WritePage';
+import EditorPage from 'pages/EditorPage';
+import TopNavLink from 'components/TopNavLink';
 
 const Header = styled.header`
   color: white;
@@ -41,13 +36,8 @@ const Logo = styled.img`
   width: auto;
 `;
 
-const checkLogin = () => {
-  return document.cookie.includes('isLogin');
-};
-
 const App: React.FC = () => {
-  const history = useHistory();
-  const [isLogin, setLogin] = useState(checkLogin());
+  const [isLogin, setLogin] = useLogin();
 
   const logout = useCallback(() => {
     fetch(`${process.env.REACT_APP_API_URL}/api/logout`, {
@@ -58,10 +48,11 @@ const App: React.FC = () => {
       .then(res => {
         if (res.message !== 'success') {
           alert('로그인 상태를 확인해주세요');
+          return;
         }
-      })
-      .finally(() => setLogin(checkLogin()));
-  }, []);
+        setLogin(false);
+      });
+  }, [setLogin]);
 
   return (
     <div className="App">
@@ -87,6 +78,7 @@ const App: React.FC = () => {
           <Route path="/login" exact component={LoginPage} />
           <Route path="/debug/:id" component={DebugPage} />
           <Route path="/write" exact component={WritePage} />
+          <Route path="/editor" exact component={EditorPage} />
           <Redirect path="*" to="/notfound" />
         </Switch>
       </BrowserRouter>

--- a/packages/frontend/src/components/Button.tsx
+++ b/packages/frontend/src/components/Button.tsx
@@ -1,0 +1,10 @@
+import styled from '@cyfm/styled';
+
+const Button = styled.button`
+  padding: 0.5em 0.7em;
+  border: 0;
+  font-size: 1.2em;
+  background-color: #f6cc00;
+`;
+
+export default Button;

--- a/packages/frontend/src/components/FullWidthViewer.tsx
+++ b/packages/frontend/src/components/FullWidthViewer.tsx
@@ -1,0 +1,11 @@
+import { Viewer } from '@toast-ui/react-editor';
+import type { RefObject } from 'react';
+
+export default class FullWidthViewer extends Viewer {
+  componentDidMount(this: { rootEl: RefObject<HTMLElement> }) {
+    Viewer.prototype.componentDidMount?.call(this);
+    const rootElement = this.rootEl.current;
+    rootElement?.style.setProperty('width', '100%');
+    rootElement?.style.setProperty('background-color', '#2F333C');
+  }
+}

--- a/packages/frontend/src/components/TestCodeEditor.tsx
+++ b/packages/frontend/src/components/TestCodeEditor.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useCallback, useRef } from 'react';
+import type { MutableRefObject, RefObject } from 'react';
+import { nanoid } from 'nanoid';
+import Button from 'components/Button';
+import styled from '@cyfm/styled';
+
+import TestCodeViewer from './TestCodeViewer';
+
+interface TestCase {
+  title: string;
+  code: string;
+  id: string;
+}
+
+const FlexWrapper = styled.div`
+  display: flex;
+`;
+
+const FullWidthWrapper = styled(FlexWrapper)`
+  width: 100%;
+`;
+
+const Wrapper = styled(FullWidthWrapper)`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+const TitleWrapper = styled(FullWidthWrapper)`
+  margin-bottom: 15px;
+`;
+
+const TestCaseWrapper = styled(FullWidthWrapper)`
+  margin-bottom: 15px;
+  flex-direction: column;
+`;
+
+const StyledInput = styled.input`
+  border: 0;
+  border-radius: 5px;
+  font-size: 1.2em;
+  padding: 15px;
+  flex-basis: 100%;
+`;
+
+const TestCodeEditor = ({
+  testCases,
+  setTestCases,
+}: {
+  testCases: TestCase[];
+  setTestCases: React.Dispatch<React.SetStateAction<TestCase[]>>;
+}) => {
+  const titleRef: MutableRefObject<HTMLInputElement | undefined> = useRef();
+  const codeRef: MutableRefObject<HTMLInputElement | undefined> = useRef();
+
+  const addTestCase = useCallback(() => {
+    const titleInput = titleRef.current as HTMLInputElement;
+    const codeInput = codeRef.current as HTMLInputElement;
+
+    const title = titleInput.value;
+    const code = codeInput.value;
+    const id = nanoid();
+
+    setTestCases(testCases => [...testCases, { title, code, id }]);
+
+    titleInput.value = '';
+    codeInput.value = '';
+  }, [titleRef, codeRef, setTestCases]);
+
+  const remove = useCallback(
+    (id: string) => {
+      setTestCases(cases => {
+        return cases.filter(({ id: caseId }) => caseId !== id);
+      });
+    },
+    [setTestCases],
+  );
+
+  return (
+    <Wrapper>
+      <TestCodeViewer testCases={testCases} remove={remove} />
+      <TestCaseWrapper>
+        <TitleWrapper>
+          <StyledInput
+            ref={titleRef}
+            type="text"
+            placeholder="제목을 입력해주세요"
+            required
+          />
+        </TitleWrapper>
+        <StyledInput
+          ref={codeRef}
+          type="text"
+          placeholder="테스트 코드를 입력해주세요"
+          required
+        />
+      </TestCaseWrapper>
+      <Button onClick={addTestCase}>+</Button>
+    </Wrapper>
+  );
+};
+
+export default TestCodeEditor;

--- a/packages/frontend/src/components/TestCodeViewer.tsx
+++ b/packages/frontend/src/components/TestCodeViewer.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import styled from '@cyfm/styled';
+
+import Button from 'components/Button';
+
+interface TestCase {
+  title: string;
+  code: string;
+  id: string;
+}
+
+interface ViewerProps {
+  testCases: TestCase[];
+  remove: (id: string) => void;
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 15px;
+`;
+
+const TestCaseTitle = styled.div`
+  border: 0;
+  border-radius: 5px;
+  font-size: 1.2em;
+  padding: 10px;
+  width: 100%;
+  color: white;
+  background-color: grey;
+  margin-bottom: 15px;
+`;
+
+const TestCaseCode = styled.div`
+  border: 0;
+  border-radius: 5px;
+  font-size: 1.2em;
+  padding: 10px;
+  width: 100%;
+  color: white;
+  background-color: black;
+  margin-bottom: 15px;
+`;
+
+const TestCodeViewer = (props: ViewerProps) => {
+  return (
+    <>
+      {props.testCases.map(testcase => {
+        return (
+          <Wrapper key={testcase.id}>
+            <TestCaseTitle>{testcase.title}</TestCaseTitle>
+            <TestCaseCode>{testcase.code}</TestCaseCode>
+            <Button onClick={(e: MouseEvent) => props.remove(testcase.id)}>
+              -
+            </Button>
+          </Wrapper>
+        );
+      })}
+    </>
+  );
+};
+
+export default TestCodeViewer;

--- a/packages/frontend/src/hooks/useLogin.ts
+++ b/packages/frontend/src/hooks/useLogin.ts
@@ -1,0 +1,12 @@
+import { useState } from 'react';
+
+export function useLogin(): [
+  boolean,
+  React.Dispatch<React.SetStateAction<boolean>>,
+] {
+  const [isLogin, setLogin] = useState<boolean>(
+    document.cookie.includes('isLogin'),
+  );
+
+  return [isLogin, setLogin];
+}

--- a/packages/frontend/src/pages/DebugPage/index.tsx
+++ b/packages/frontend/src/pages/DebugPage/index.tsx
@@ -4,33 +4,22 @@ import { useRouteMatch } from 'react-router-dom';
 
 import AceEditor from 'react-ace';
 import { Ace } from 'ace-builds';
-import { Viewer } from '@toast-ui/react-editor';
+import type { Viewer } from '@toast-ui/react-editor';
 
 import babelParser from 'prettier/parser-babel';
 import prettier from 'prettier/standalone';
 
 import runner from './debug';
 import styled from '@cyfm/styled';
+import FullWidthViewer from 'components/FullWidthViewer';
+
+import EditorPage from 'pages/EditorPage';
+import Button from 'components/Button';
 
 import 'ace-builds/src-noconflict/mode-javascript';
 import 'ace-builds/src-noconflict/theme-twilight';
 import '@toast-ui/editor/dist/toastui-editor.css';
 import '@toast-ui/editor/dist/theme/toastui-editor-dark.css';
-
-class FullWidthViewer extends Viewer {
-  componentDidMount(this: { rootEl: RefObject<HTMLElement> }) {
-    Viewer.prototype.componentDidMount?.call(this);
-    const rootElement = this.rootEl.current;
-    rootElement?.style.setProperty('width', '100%');
-    rootElement?.style.setProperty('background-color', '#2F333C');
-  }
-}
-
-const FlexWrapper = styled.div`
-  display: flex;
-  min-width: 100vw;
-  min-height: 100vh;
-`;
 
 const ViewerWrapper = styled.div`
   display: flex;
@@ -55,44 +44,10 @@ const ConsoleWrapper = styled.div`
   box-sizing: border-box;
 `;
 
-const Button = styled.button`
-  padding: 0.5em 0.7em;
-  border: 0;
-  font-size: 1.2em;
-  background-color: #f6cc00;
-`;
-
 const ButtonFooter = styled.div`
   display: flex;
   justify-content: space-evenly;
   background: #1c1d20;
-`;
-
-const minWidth = 250;
-const LeftFlexColumnWrapper = styled.div<{ width: string }>`
-  display: flex;
-  flex-direction: column;
-  flex-basis: ${props => props.width}px;
-  min-width: ${minWidth}px;
-`;
-
-const RightFlexColumnWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  min-width: ${minWidth}px;
-`;
-
-const controllerWidth = 5;
-const FlexColumnController = styled.div`
-  display: inline-block;
-  width: ${controllerWidth}px;
-  background-color: #999;
-  border-color: #444;
-  border-style: solid;
-  border-top: 2px;
-  border-bottom: 2px;
-  cursor: col-resize;
 `;
 
 const DebugPage: React.FC = () => {
@@ -100,10 +55,6 @@ const DebugPage: React.FC = () => {
   const [initCode, setInitCode] = useState('');
   const [code, setCode] = useState('');
   const [testCode, setTestCode] = useState([]);
-  const [isMouseDown, setIsMouseDown] = useState(false);
-  const [leftFlexColumnWidth, setLeftFlexColumnWidth] = useState(
-    `${(window.innerWidth - controllerWidth) / 2}`,
-  );
 
   const viewerRef: MutableRefObject<Viewer | undefined> = useRef();
   const editorRef: MutableRefObject<(AceEditor & Ace.Editor) | undefined> =
@@ -160,23 +111,6 @@ const DebugPage: React.FC = () => {
     }
   }, [testCode, editorRef, setOutput]);
 
-  const onControllerMouseDown = useCallback((event: MouseEvent): void => {
-    setIsMouseDown(true);
-  }, []);
-
-  const onControllerMouseMove = useCallback(
-    (event: MouseEvent): void => {
-      if (isMouseDown) {
-        setLeftFlexColumnWidth(`${event.pageX - controllerWidth / 2}`);
-      }
-    },
-    [isMouseDown],
-  );
-
-  const onControllerMouseUp = useCallback((event: MouseEvent): void => {
-    setIsMouseDown(false);
-  }, []);
-
   const initializeCode = useCallback(() => {
     const editor = editorRef.current as Ace.Editor;
     editor.setValue(initCode);
@@ -185,48 +119,49 @@ const DebugPage: React.FC = () => {
   }, [initCode]);
 
   return (
-    <FlexWrapper
-      onMouseMove={onControllerMouseMove}
-      onMouseUp={onControllerMouseUp}
-    >
-      <LeftFlexColumnWrapper width={leftFlexColumnWidth}>
-        <ViewerWrapper>
-          <FullWidthViewer
-            theme="dark"
-            ref={viewerRef as RefObject<FullWidthViewer>}
-          />
-        </ViewerWrapper>
-        <ConsoleWrapper>
-          <div>{output}</div>
-        </ConsoleWrapper>
-      </LeftFlexColumnWrapper>
-      <FlexColumnController onMouseDown={onControllerMouseDown} />
-      <RightFlexColumnWrapper>
-        <EditorWrapper>
-          <AceEditor
-            onLoad={onLoad}
-            onChange={onChange}
-            mode="javascript"
-            width="100%"
-            height="800px"
-            theme="twilight"
-            name="test"
-            fontSize={16}
-            value={code}
-            editorProps={{ $blockScrolling: true }}
-            setOptions={{
-              tabSize: 2,
-              enableBasicAutocompletion: true,
-              enableLiveAutocompletion: true,
-            }}
-          />
-        </EditorWrapper>
-        <ButtonFooter>
-          <Button onClick={initializeCode}>초기화</Button>
-          <Button onClick={onExecute}>실행</Button>
-        </ButtonFooter>
-      </RightFlexColumnWrapper>
-    </FlexWrapper>
+    <EditorPage
+      left={
+        <>
+          <ViewerWrapper>
+            <FullWidthViewer
+              theme="dark"
+              ref={viewerRef as RefObject<FullWidthViewer>}
+            />
+          </ViewerWrapper>
+          ,
+          <ConsoleWrapper>
+            <div>{output}</div>
+          </ConsoleWrapper>
+        </>
+      }
+      right={
+        <>
+          <EditorWrapper>
+            <AceEditor
+              onLoad={onLoad}
+              onChange={onChange}
+              mode="javascript"
+              width="100%"
+              height="800px"
+              theme="twilight"
+              name="test"
+              fontSize={16}
+              value={code}
+              editorProps={{ $blockScrolling: true }}
+              setOptions={{
+                tabSize: 2,
+                enableBasicAutocompletion: true,
+                enableLiveAutocompletion: true,
+              }}
+            />
+          </EditorWrapper>
+          <ButtonFooter>
+            <Button onClick={initializeCode}>초기화</Button>
+            <Button onClick={onExecute}>실행</Button>
+          </ButtonFooter>
+        </>
+      }
+    />
   );
 };
 

--- a/packages/frontend/src/pages/EditorPage/index.tsx
+++ b/packages/frontend/src/pages/EditorPage/index.tsx
@@ -1,0 +1,85 @@
+import { useState, useCallback } from 'react';
+
+import styled from '@cyfm/styled';
+
+const minWidth = 250;
+const controllerWidth = 5;
+
+const FlexWrapper = styled.div`
+  display: flex;
+  min-width: 100vw;
+  min-height: 100vh;
+`;
+
+const LeftFlexColumnWrapper = styled.div<{ width: string }>`
+  display: flex;
+  flex-direction: column;
+  flex-basis: ${props => props.width}px;
+  min-width: ${minWidth}px;
+`;
+
+const RightFlexColumnWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-width: ${minWidth}px;
+`;
+
+const FlexColumnController = styled.div`
+  display: inline-block;
+  width: ${controllerWidth}px;
+  background-color: #999;
+  border-color: #444;
+  border-style: solid;
+  border-top: 2px;
+  border-bottom: 2px;
+  cursor: col-resize;
+`;
+
+interface SlotProps {
+  left: React.ReactNode;
+  right: React.ReactNode;
+}
+
+const EditorPage = (props: SlotProps) => {
+  const [isMouseDown, setIsMouseDown] = useState(false);
+  const [leftFlexColumnWidth, setLeftFlexColumnWidth] = useState(
+    `${(window.innerWidth - controllerWidth) / 2}`,
+  );
+
+  const onControllerMouseDown = useCallback((event: MouseEvent): void => {
+    setIsMouseDown(true);
+  }, []);
+
+  const onControllerMouseMove = useCallback(
+    (event: MouseEvent): void => {
+      if (isMouseDown) {
+        setLeftFlexColumnWidth(`${event.pageX - controllerWidth / 2}`);
+      }
+    },
+    [isMouseDown],
+  );
+
+  const onControllerMouseUp = useCallback((event: MouseEvent): void => {
+    setIsMouseDown(false);
+  }, []);
+
+  return (
+    <>
+      <FlexWrapper
+        onMouseMove={onControllerMouseMove}
+        onMouseUp={onControllerMouseUp}
+      >
+        <LeftFlexColumnWrapper width={leftFlexColumnWidth}>
+          {props.left}
+        </LeftFlexColumnWrapper>
+        <FlexColumnController onMouseDown={onControllerMouseDown} />
+        <RightFlexColumnWrapper width={leftFlexColumnWidth}>
+          {props.right}
+        </RightFlexColumnWrapper>
+      </FlexWrapper>
+    </>
+  );
+};
+
+export default EditorPage;

--- a/packages/frontend/src/pages/WritePage/index.tsx
+++ b/packages/frontend/src/pages/WritePage/index.tsx
@@ -1,39 +1,138 @@
-import React, { useRef } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { Editor } from '@toast-ui/react-editor';
 import AceEditor from 'react-ace';
+import { Ace } from 'ace-builds';
 import type { MutableRefObject, RefObject } from 'react';
+import { Redirect } from 'react-router-dom';
+
+import { useLogin } from 'hooks/useLogin';
 
 import 'ace-builds/src-noconflict/theme-twilight';
 
 import '@toast-ui/editor/dist/toastui-editor.css';
 import '@toast-ui/editor/dist/theme/toastui-editor-dark.css';
 
+import styled from '@cyfm/styled';
+import Button from 'components/Button';
+import EditorPage from 'pages/EditorPage';
+import TestCodeEditor from 'components/TestCodeEditor';
+
+interface TestCase {
+  title: string;
+  code: string;
+  id: string;
+}
+
+const TestCodeWrapper = styled.div`
+  height: 500px;
+  width: 100%;
+  background: teal;
+  padding: 15px;
+  overflow-x: hidden;
+  overflow-y: auto;
+`;
+
+const ButtonFooter = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+  background: #1c1d20;
+`;
+
 const WritePage = () => {
+  const [isLogin] = useLogin();
+  const [content, setContent] = useState('');
+  const [code, setCode] = useState('');
+
   const markdownRef: MutableRefObject<Editor | undefined> = useRef();
+  const editorRef: MutableRefObject<(AceEditor & Ace.Editor) | undefined> =
+    useRef();
+
+  const [testCases, setTestCases]: [
+    TestCase[],
+    React.Dispatch<React.SetStateAction<TestCase[]>>,
+  ] = useState<TestCase[]>([]);
+
+  const onChange = useCallback(setCode, [setCode]);
+
+  const onLoad = useCallback(
+    editor => {
+      editorRef.current = editor;
+    },
+    [editorRef],
+  );
 
   function onMarkdownEditorLoad(this: Editor) {
     markdownRef.current = this;
   }
 
+  const submit = async (e: MouseEvent) => {
+    const payload = {
+      code: code,
+      content: (markdownRef.current as Editor).getInstance().getMarkdown(),
+      testCode: [...testCases].map(({ code }) => code),
+      title: '테스트',
+      level: 2,
+      category: 'JavaScript',
+    };
+
+    await fetch(`${process.env.REACT_APP_API_URL}/api/problem`, {
+      method: 'POST',
+      credentials: 'include',
+      body: JSON.stringify(payload),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  };
+
   return (
     <>
-      <Editor
-        previewStyle="vertical"
-        height="400px"
-        initialEditType="wysiwyg"
-        hideModeSwitch
-        placeholder="### 마크다운 문법에 맞춰 값을 입력해주세요."
-        theme="dark"
-        usageStatistics={false}
-        onLoad={onMarkdownEditorLoad}
-        ref={markdownRef as RefObject<Editor>}
-      />
-      <AceEditor
-        mode="javascript"
-        theme="twilight"
-        name="test"
-        editorProps={{ $blockScrolling: true }}
-      />
+      {isLogin ? (
+        <EditorPage
+          left={
+            <>
+              <Editor
+                previewStyle="vertical"
+                height="800px"
+                initialEditType="wysiwyg"
+                hideModeSwitch
+                placeholder="### 마크다운 문법에 맞춰 값을 입력해주세요."
+                theme="dark"
+                usageStatistics={false}
+                onLoad={onMarkdownEditorLoad}
+                ref={markdownRef as RefObject<Editor>}
+              />
+            </>
+          }
+          right={
+            <>
+              <AceEditor
+                onLoad={onLoad}
+                onChange={onChange}
+                mode="javascript"
+                width="100%"
+                height="400px"
+                theme="twilight"
+                name="test"
+                fontSize={16}
+                editorProps={{ $blockScrolling: true }}
+              />
+              <TestCodeWrapper>
+                <TestCodeEditor
+                  testCases={testCases}
+                  setTestCases={setTestCases}
+                />
+              </TestCodeWrapper>
+              <ButtonFooter>
+                <Button>실행</Button>
+                <Button onClick={submit}>제출</Button>
+              </ButtonFooter>
+            </>
+          }
+        />
+      ) : (
+        <Redirect to="/login" />
+      )}
     </>
   );
 };

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "src"
   },
   "include": ["src/**/*"],
   "extends": "../../tsconfig.json"

--- a/packages/styled/index.js
+++ b/packages/styled/index.js
@@ -29,7 +29,7 @@ function processTemplate(strings, args, props) {
 const createStyledComponent =
   tag =>
   (strings, ...args) => {
-    return props => {
+    return React.forwardRef((props, ref) => {
       const css = processTemplate(strings, args, props);
       return React.createElement(tag, {
         ...props,
@@ -38,8 +38,9 @@ const createStyledComponent =
           /* eslint-disable-next-line react/prop-types, react/destructuring-assignment */
           ...props.style,
         },
+        ref,
       });
-    };
+    });
   };
 
 const extend = Base => createStyledComponent(Base);


### PR DESCRIPTION
### 진행 상황
- `Styled` 패키지에 `forwardRef`를 적용하여 하위 엘리먼트에 `Ref`를 적용 가능
- 문제 풀이 페이지와 문제 출제 페이지의 코드 에디터와 뷰어, 마크다운 에디터의 레이아웃 코드 분리
- 문제 출제 API POST 요청 기능 구현