### PR TITLE
fix: Dockerfile 내의 다중 COPY 시 경로 설정 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node-base as frontend-builder
 WORKDIR /app
 
 COPY packages/ packages/
-COPY ["package.json", "yarn.lock", "lerna.json", "."]
+COPY ["package.json", "yarn.lock", "lerna.json", "./"]
 RUN yarn --frozen-lockfile --ignore-scripts
 
 COPY tsconfig.json .


### PR DESCRIPTION
- Dockerfile 내의 다중 COPY 시 경로 설정 변경
- `.` => `./`