### PR TITLE
chore: 백엔드 배포환경 트랜스파일 빌드 적용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,4 @@
 FROM node:14.17.3 as node-base
-FROM node-base as frontend-builder
-
-WORKDIR /app
-
-COPY packages/ packages/
-COPY ["package.json", "yarn.lock", "lerna.json", "./"]
-RUN yarn --frozen-lockfile --ignore-scripts
-
-ARG API_URL
-ARG CLIENT_ID
-ENV REACT_APP_API_URL=$API_URL
-ENV REACT_APP_CLIENT_ID=$CLIENT_ID
-
-COPY tsconfig.json .
-RUN yarn bootstrap --ignore-scripts && \
-    yarn build:frontend
 
 FROM node-base as nginx-server
 
@@ -23,16 +7,54 @@ RUN apt-get update && \
 
 COPY nginx.conf /etc/nginx/nginx.conf
 
-FROM nginx-server as backend-builder
 
-COPY --from=frontend-builder /app /app
+FROM node-base as repository
 
 WORKDIR /app
-RUN mv packages/frontend/build/* /var/www/html/
-COPY package.json .
+
+COPY packages/ packages/
+COPY ["package.json", "yarn.lock", "lerna.json", "tsconfig.json", "./"]
+
+
+FROM node-base as frontend-builder
+
+COPY --from=repository /app /app
+
+WORKDIR /app
+RUN yarn global add lerna && lerna link
+
+WORKDIR /app/packages/frontend
+
+ARG API_URL
+ARG CLIENT_ID
+ENV REACT_APP_API_URL=$API_URL
+ENV REACT_APP_CLIENT_ID=$CLIENT_ID
+
+RUN yarn --frozen-lockfile --ignore-scripts && \
+    yarn build
+
+
+FROM node-base as backend-builder
+
+COPY --from=repository /app /app
+WORKDIR /app/packages/backend
+
+RUN yarn --frozen-lockfile --ignore-scripts && \
+    yarn build
+
+
+FROM nginx-server as production
+
+COPY --from=backend-builder /app/packages/backend/package.json /app/
+
+WORKDIR /app
+RUN yarn --frozen-lockfile --ignore-scripts --prod
+
+COPY --from=backend-builder /app/packages/backend/dist /app/dist
+COPY --from=frontend-builder /app/packages/frontend/build /var/www/html
 
 EXPOSE 80
 EXPOSE 3001
 
 ENV NODE_ENV=production
-CMD ["sh", "-c", "nginx -g 'daemon on;' && yarn start:backend"]
+CMD ["sh", "-c", "nginx -g 'daemon on;' && yarn start:prod"]

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "start": "nodemon --exec ts-node -r dotenv/config src/app.ts dotenv_config_path=.env.development",
+    "start:prod": "node -r dotenv/config dist/app.js dotenv_config_path=.env.production",
     "build": "tsc"
   },
   "dependencies": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,6 @@
     "mongoose": "^6.0.12",
     "mysql2": "^2.3.3-rc.0",
     "reflect-metadata": "^0.1.13",
-    "ts-node": "^10.4.0",
     "typeorm": "^0.2.38"
   },
   "devDependencies": {
@@ -25,6 +24,7 @@
     "@types/mongoose": "^5.11.97",
     "@types/node": "^16.11.6",
     "nodemon": "^2.0.15",
+    "ts-node": "^10.4.0",
     "typescript": "^4.4.4"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "start": "nodemon --exec ts-node -r dotenv/config src/app.ts dotenv_config_path=.env.development",
-    "build": "exit 1"
+    "build": "tsc"
   },
   "dependencies": {
     "axios": "^0.24.0",

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "outDir": "dist"
   },
   "extends": "../../tsconfig.json",
   "include": ["src/**/*", "src/settings/ormConfig.ts"]


### PR DESCRIPTION
- `dist` 경로로 백엔드 JS 파일을 emit
- 캐시를 활용할 수 있도록 Dockerfile 명령 변경
- 배포환경 시작 스크립트 `start:prod` 명령 추가