### PR TITLE
fix: worker thread pool의 maxworker 개수 변경 및 timeout 처리

### DIFF
--- a/packages/backend/src/settings/socketConfig.ts
+++ b/packages/backend/src/settings/socketConfig.ts
@@ -29,7 +29,7 @@ const getTestCode = async problemId => {
 };
 
 export const socketConnection = httpServer => {
-  const pool = workerpool.pool({ maxWorkers: 5 });
+  const pool = workerpool.pool({ maxWorkers: 16 });
 
   const io = new Server(httpServer, {
     cors: { origin: process.env.ORIGIN_URL },

--- a/packages/backend/src/settings/socketConfig.ts
+++ b/packages/backend/src/settings/socketConfig.ts
@@ -14,6 +14,7 @@ const chaiString = fs.readFileSync(path.join(chaiPath, 'chai.js')).toString();
 const gradingWithWorkerpool = ({ pool, socket, code, testCode }) => {
   pool
     .exec(debug.runner, [{ chaiString, code, testCode }])
+    .timeout(5000)
     .then(result => {
       socket.emit('result', result);
     })


### PR DESCRIPTION
## 진행 상황
- worker thread pool의 maxworker 개수 변경
- worker timeout 처리(5초)