### PR TITLE
refactor: http api 방식에서 소켓 통신 방식으로 채점 결과를 저장하도록 방식 변경

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -16,9 +16,16 @@ import { router as problemsController } from './controller/problemsController';
 import { router as problemCodeController } from './controller/problemCodeController';
 import { router as loginController } from './controller/loginController';
 import { router as logoutController } from './controller/logoutController';
-import { router as submitController } from './controller/submitController';
 
 const app: express.Application = express();
+
+const sessionConfig = session({
+  secret: 'GyungGi_FourSkyking',
+  store: sessionStore,
+  resave: false,
+  saveUninitialized: false,
+  cookie: { maxAge: 1000 * 3600 * 12 },
+});
 
 const server = createServer(app);
 
@@ -39,26 +46,17 @@ app.use(
   },
 );
 
-app.use(
-  session({
-    secret: 'GyungGi_FourSkyking',
-    store: sessionStore,
-    resave: false,
-    saveUninitialized: false,
-    cookie: { maxAge: 1000 * 3600 * 12 },
-  }),
-);
+app.use(sessionConfig);
 
 app.use('/api/problems', problemsController);
 app.use('/api/problem', problemController);
 app.use('/api/debug', problemCodeController);
 app.use('/api/login', loginController);
 app.use('/api/logout', logoutController);
-app.use('/api/submit', submitController);
 
 createConnection(mysqlConnectionOptions).then(() => {
   const port = process.env.PORT || 3001;
-  socketConnection(server);
+  socketConnection(server, sessionConfig);
   server.listen(port, () => {
     /* eslint-disable-next-line no-console */
     console.log(`Running Server port ${port}`);

--- a/packages/backend/src/controller/submitController.ts
+++ b/packages/backend/src/controller/submitController.ts
@@ -1,9 +1,0 @@
-import express from 'express';
-import { saveSubmit } from '../service/submitService';
-import { isLogin } from '../service/loginService';
-
-const router = express.Router();
-
-router.post('/', isLogin, saveSubmit);
-
-export { router };

--- a/packages/backend/src/service/submitService.ts
+++ b/packages/backend/src/service/submitService.ts
@@ -1,10 +1,8 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-disable no-plusplus */
 /* eslint-disable dot-notation */
-import express from 'express';
 import { SubmitCodeModel } from '../settings/mongoConfig';
 import { SubmitLog } from '../model/SubmitLog';
-import { User } from '../model/User';
 import { Problem } from '../model/Problem';
 
 const saveSubmitCode = async ({ code, testResult }) => {
@@ -36,19 +34,16 @@ const saveSubmitLog = async ({ problem, user, codeId, testResult }) => {
   await submitLog.save();
 };
 
-const saveSubmit = async (req: express.Request, res: express.Response) => {
+const saveSubmit = async ({ user, code, testResult, problemCodeId }) => {
   try {
-    const user = await User.findOne({ name: req.session['name'] });
-    const { code, testResult, problemCodeId } = req.body;
     const problem = await Problem.findOne({ codeId: problemCodeId });
     const codeData = await saveSubmitCode({ code, testResult });
     const codeId = getCodeId(codeData);
 
-    await saveSubmitLog({ problem, user, codeId, testResult });
-
-    res.status(200).json({ message: 'submit success' });
+    const result = await saveSubmitLog({ problem, user, codeId, testResult });
+    return result;
   } catch (err) {
-    res.status(500).json({ message: 'submit fail', error: err.message });
+    return err;
   }
 };
 

--- a/packages/backend/src/service/userService.ts
+++ b/packages/backend/src/service/userService.ts
@@ -1,0 +1,8 @@
+import { User } from '../model/User';
+
+const getUserByName = async name => {
+  const user = await User.findOne({ name });
+  return user;
+};
+
+export { getUserByName };

--- a/packages/backend/src/settings/socketConfig.ts
+++ b/packages/backend/src/settings/socketConfig.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-return-await */
 /* eslint-disable prefer-destructuring */
 import fs from 'fs';
 import path from 'path';
@@ -5,21 +6,25 @@ import path from 'path';
 import { Server } from 'socket.io';
 import * as workerpool from 'workerpool';
 import { debug } from '../service/debugService';
+import { getUserByName } from '../service/userService';
+import { saveSubmit } from '../service/submitService';
 import { ProblemCodeModel } from './mongoConfig';
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const chaiPath = path.dirname(require.resolve('chai'));
 const chaiString = fs.readFileSync(path.join(chaiPath, 'chai.js')).toString();
 
-const gradingWithWorkerpool = ({ pool, socket, code, testCode }) => {
-  pool
+const gradingWithWorkerpool = async ({ pool, socket, code, testCode }) => {
+  return await pool
     .exec(debug.runner, [{ chaiString, code, testCode }])
     .timeout(5000)
     .then(result => {
       socket.emit('result', result);
+      return result;
     })
     .catch(err => {
       socket.emit('error', err);
+      return err;
     });
 };
 
@@ -28,17 +33,35 @@ const getTestCode = async problemId => {
   return problemCodeData.testCode;
 };
 
-export const socketConnection = httpServer => {
+export const socketConnection = (httpServer, sessionConfig) => {
   const pool = workerpool.pool({ maxWorkers: 16 });
 
   const io = new Server(httpServer, {
-    cors: { origin: process.env.ORIGIN_URL },
+    cors: { origin: process.env.ORIGIN_URL, credentials: true },
   });
 
-  io.on('connection', socket => {
+  io.use((socket, next) => {
+    sessionConfig(socket.request, {}, next);
+  });
+
+  io.on('connection', async socket => {
+    const session = (socket.request as unknown as { session: unknown })
+      ?.session;
+    const user = await getUserByName((session as { name: unknown })?.name);
+
+    if (!user) {
+      socket.disconnect();
+    }
     socket.on('submit', async ({ code, id }) => {
       const testCode = await getTestCode(id);
-      gradingWithWorkerpool({ pool, socket, code, testCode: [...testCode] });
+      const result = await gradingWithWorkerpool({
+        pool,
+        socket,
+        code,
+        testCode: [...testCode],
+      });
+
+      await saveSubmit({ user, problemCodeId: id, code, testResult: result });
     });
 
     socket.once('forceDisconnect', () => {

--- a/packages/frontend/src/pages/DebugPage/index.tsx
+++ b/packages/frontend/src/pages/DebugPage/index.tsx
@@ -75,10 +75,9 @@ const DebugPage: React.FC = () => {
   const id = match?.params.id;
 
   useEffect(() => {
-    socket = io(`${process.env.REACT_APP_API_URL}`);
+    socket = io(`${process.env.REACT_APP_API_URL}`, { withCredentials: true });
 
     socket.on('result', async result => {
-      await requestSubmit(result);
       setLoading(false);
       if (checkResult(result)) {
         setSuccess(true);
@@ -131,31 +130,6 @@ const DebugPage: React.FC = () => {
 
   const checkResult = (result: string[]) => {
     return result.every(value => value === 'success');
-  };
-
-  const requestSubmit = async (result: [string]) => {
-    const payload = {
-      problemCodeId: id,
-      testResult: result,
-      code: code,
-    };
-
-    try {
-      let res = await fetch(`${process.env.REACT_APP_API_URL}/api/submit`, {
-        method: 'POST',
-        credentials: 'include',
-        body: JSON.stringify(payload),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-      res = await res.json();
-      return res;
-    } catch (err) {
-      setLoading(false);
-      setError(true);
-      return err;
-    }
   };
 
   const onSubmit = useCallback(async () => {


### PR DESCRIPTION
## 진행 사항
- 채점 관련 http api 제거
- socket submit 이벤트 발생 시 채점을 진행하고 결과를 즉시 DB에 저장하도록 변경


(ps. 실시간으로 테스트 결과 하나하나 마다 따로 이벤트를 보내는 것은 회의 후 구현 예정)