### PR TITLE
chore: Husky 커밋 관련 훅 개선

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,10 +1,16 @@
 #!/bin/sh
 
-if test "" = "$(sed -n -E -e '/^#/d' -e '/^([a-z]+): /,1p' "$1")"; then
-    echo >&2 '메시지는 반드시 "<type>: "으로 시작해야 합니다'
-    exit 1
-fi
-
 # 주석 제거
 sed -i.bak -e '/^#/d' "$1"
+
+if test "" = "$(grep -o -E '^Merge ' "$1")" && \
+    test "" = "$(sed -n -E \
+    -e 's/^(fixup|amend|squash)\! //' \
+    -e '/^([a-z]+)(\([^\)]+\))?\!?: /,1p' "$1")"; then
+
+    echo >&2 '메시지는 반드시 "<타입>[적용 범위(선택 사항)]: "으로 시작해야 합니다'
+    echo >&2 '참고: https://www.conventionalcommits.org/ko/v1.0.0-beta.4/'
+
+    exit 1
+fi
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,14 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+# From .git/hooks/pre-commit
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+git diff-index --check --cached $against -- >&2 || exit 1
+
 npx lint-staged


### PR DESCRIPTION
## 변경 사항
- 추가적인 [Conventional commits][1] 문법을 지원하도록 수정
  - e.g. `fix!: `, `chore(docker): `
- 충돌 마커, 불필요한 공백이 커밋 대상 파일에 포함이 되어있는지에 대하여 검사하도록 수정

[1]: https://www.conventionalcommits.org/ko/v1.0.0-beta.4/