### PR TITLE
refactor: 소켓 통신을 이용하여 실시간으로 테스트 결과값 전달

### DIFF
--- a/packages/backend/src/service/debugService.ts
+++ b/packages/backend/src/service/debugService.ts
@@ -2,22 +2,19 @@
 /* eslint-disable no-new-func */
 
 const runner = ({ chaiString, code, testCode }) => {
-  const result = testCode.map(test => {
-    try {
-      const codeRunner = new Function(
-        `${chaiString}
+  try {
+    const codeRunner = new Function(
+      `${chaiString}
         const {expect} = chai;
-                ${code}
-                ${test}
-            `,
-      );
-      codeRunner();
-      return 'success';
-    } catch (err) {
-      return err.toString();
-    }
-  });
-  return result;
+        ${code}
+        ${testCode}
+      `,
+    );
+    codeRunner();
+    return 'success';
+  } catch (err) {
+    return err.toString();
+  }
 };
 
 export const debug = {

--- a/packages/backend/src/settings/socketConfig.ts
+++ b/packages/backend/src/settings/socketConfig.ts
@@ -22,7 +22,7 @@ const gradingWithWorkerpool = async ({ pool, code, testCode }) => {
       return result;
     })
     .catch(err => {
-      return err;
+      return err.message;
     });
 };
 


### PR DESCRIPTION
## 진행 상황
- 소켓 통신을 이용하여 실시간으로 테스트 결과값 전달
- 백엔드 로직 수정
- 에러 시 에러의 메시지를 전달하도록 수정

- 현재는 에러에 대한 문자열을 보내지만, 리팩토링 기간에 에러 코드를 전송하도록 수정할 예정