### PR TITLE
feat: 에디터 수정시 페이지 이동 방지 기능 추가

### DIFF
--- a/packages/frontend/src/hooks/useBlockUnload.ts
+++ b/packages/frontend/src/hooks/useBlockUnload.ts
@@ -1,0 +1,55 @@
+import { useRef, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+
+const CONFIRM_MESSAGE = `작성 중인 내용이 사라집니다\n\n페이지를 나가시거나 새로고침 하시겠습니까?`;
+export const useBlockUnload = <T>(
+  dependencies: T,
+  didChange = (prev: T, deps: T) => !Object.is(prev, deps),
+) => {
+  const history = useHistory();
+  const historyRef = useRef<string>('');
+  const prevRef = useRef<T>(dependencies);
+
+  useEffect(() => {
+    const blockUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      return (event.returnValue = CONFIRM_MESSAGE);
+    };
+
+    const confirmBeforeGo = () => {
+      if (!window.confirm(CONFIRM_MESSAGE)) {
+        history.push(historyRef.current, {
+          prev: prevRef.current,
+          deps: dependencies,
+        });
+      }
+    };
+
+    if (!historyRef.current) {
+      historyRef.current = history.location.pathname;
+    }
+
+    if (prevRef.current) {
+      if (didChange(prevRef.current, dependencies)) {
+        // 새로고침 방지
+        window.addEventListener('beforeunload', blockUnload);
+        // 앞/뒤로가기 방지
+        window.addEventListener('popstate', confirmBeforeGo);
+        // 라우팅 방지
+        const unlisten = history.listen((location, action) => {
+          if (action === 'PUSH' && location.pathname !== historyRef.current) {
+            confirmBeforeGo();
+          }
+        });
+
+        return () => {
+          window.removeEventListener('beforeunload', blockUnload);
+          window.removeEventListener('popstate', confirmBeforeGo);
+          unlisten();
+        };
+      }
+    } else {
+      prevRef.current = dependencies;
+    }
+  }, [history, historyRef, prevRef, didChange, dependencies]);
+};

--- a/packages/frontend/src/pages/DebugPage/index.tsx
+++ b/packages/frontend/src/pages/DebugPage/index.tsx
@@ -20,6 +20,8 @@ import MessageModal from 'components/Modal/MessageModal';
 import ConfirmModal from 'components/Modal/ConfirmModal';
 import LoadingModal from 'components/Modal/LoadingModal';
 
+import { useBlockUnload } from 'hooks/useBlockUnload';
+
 import 'ace-builds/src-noconflict/mode-javascript';
 import 'ace-builds/src-noconflict/theme-twilight';
 import '@toast-ui/editor/dist/toastui-editor.css';
@@ -67,6 +69,8 @@ const DebugPage: React.FC = () => {
   const [isTimeover, setTimeover] = useState(false);
   const [isError, setError] = useState(false);
 
+  useBlockUnload(code);
+
   const viewerRef: MutableRefObject<Viewer | undefined> = useRef();
   const editorRef: MutableRefObject<(AceEditor & Ace.Editor) | undefined> =
     useRef();
@@ -111,7 +115,7 @@ const DebugPage: React.FC = () => {
         });
         setContent(content);
         setInitCode(prettierCode);
-        setCode(prettierCode);
+        setCode(prev => (prev ? prev : prettierCode));
         setTestCode(testCode);
         viewerRef.current?.getInstance().setMarkdown(content);
       });
@@ -172,6 +176,15 @@ const DebugPage: React.FC = () => {
   }, [initCode]);
 
   const history = useHistory();
+  useEffect(() => {
+    console.log(history);
+    if (history.location.state) {
+      const code = (history.location.state as { deps?: string })?.deps ?? '';
+      if (code) {
+        setCode(code);
+      }
+    }
+  }, []);
 
   return (
     <EditorPage

--- a/packages/frontend/src/pages/DebugPage/index.tsx
+++ b/packages/frontend/src/pages/DebugPage/index.tsx
@@ -1,5 +1,10 @@
-/* eslint-disable react-hooks/exhaustive-deps */
-import React, { useState, useRef, useCallback, useEffect } from 'react';
+import React, {
+  useState,
+  useReducer,
+  useRef,
+  useCallback,
+  useEffect,
+} from 'react';
 import type { MutableRefObject, RefObject } from 'react';
 import { useRouteMatch, useHistory } from 'react-router-dom';
 
@@ -30,6 +35,8 @@ import '@toast-ui/editor/dist/theme/toastui-editor-dark.css';
 import io, { Socket } from 'socket.io-client';
 import { DefaultEventsMap } from '@socket.io/component-emitter';
 
+import { debugReducer } from './reducer';
+
 const ViewerWrapper = styled.div`
   display: flex;
   flex-basis: 50%;
@@ -59,17 +66,22 @@ const ButtonFooter = styled.div`
 let socket: Socket<DefaultEventsMap, DefaultEventsMap>;
 
 const DebugPage: React.FC = () => {
-  const [, setContent] = useState('');
-  const [initCode, setInitCode] = useState('');
-  const [code, setCode] = useState('');
-  const [testCode, setTestCode] = useState([]);
+  const [debugStates, dispatch] = useReducer(debugReducer, {
+    initCode: '',
+    content: '',
+    code: '',
+    testCode: [],
+  });
+  const [output, setOutput] = useState('');
   const [isLoading, setLoading] = useState(false);
   const [isSuccess, setSuccess] = useState(false);
   const [isFail, setFail] = useState(false);
   const [isTimeover, setTimeover] = useState(false);
   const [isError, setError] = useState(false);
 
-  useBlockUnload(code);
+  useBlockUnload(debugStates, (_, deps) => {
+    return deps.initCode !== deps.code;
+  });
 
   const viewerRef: MutableRefObject<Viewer | undefined> = useRef();
   const editorRef: MutableRefObject<(AceEditor & Ace.Editor) | undefined> =
@@ -103,27 +115,44 @@ const DebugPage: React.FC = () => {
   useEffect(() => {
     fetch(`${process.env.REACT_APP_API_URL}/api/debug/${id}`)
       .then(res => res.json())
-      .then(({ content, code, testCode }) => {
-        const prettierCode = prettier.format(code, {
-          singleQuote: true,
-          semi: true,
-          tabWidth: 2,
-          trailingComma: 'all',
-          arrowParens: 'avoid',
-          parser: 'babel',
-          plugins: [babelParser],
-        });
-        setContent(content);
-        setInitCode(prettierCode);
-        setCode(prev => (prev ? prev : prettierCode));
-        setTestCode(testCode);
-        viewerRef.current?.getInstance().setMarkdown(content);
-      });
+      .then(
+        ({
+          content,
+          code,
+          testCode,
+        }: {
+          content: string;
+          code: string;
+          testCode: string[];
+        }) => {
+          const prettierCode = prettier.format(code, {
+            singleQuote: true,
+            semi: true,
+            tabWidth: 2,
+            trailingComma: 'all',
+            arrowParens: 'avoid',
+            parser: 'babel',
+            plugins: [babelParser],
+          });
+
+          dispatch({
+            type: 'init',
+            payload: {
+              code: prettierCode,
+              content,
+              testCode,
+            },
+          });
+
+          viewerRef.current?.getInstance().setMarkdown(content);
+        },
+      );
   }, [id]);
 
-  const [output, setOutput] = useState('');
-
-  const onChange = useCallback(setCode, [setCode]);
+  const onChange = useCallback(
+    code => dispatch({ type: 'setCode', payload: { code } }),
+    [],
+  );
 
   const onLoad = useCallback(
     editor => {
@@ -143,7 +172,8 @@ const DebugPage: React.FC = () => {
       code: (editorRef.current as Ace.Editor).getValue() as string,
       id,
     });
-  }, [testCode]);
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [debugStates.testCode]);
 
   const onExecute = useCallback(async () => {
     const loadTimer = setTimeout(() => {
@@ -152,7 +182,7 @@ const DebugPage: React.FC = () => {
 
     const result = await runner({
       code: (editorRef.current as Ace.Editor).getValue() as string,
-      testCode,
+      testCode: debugStates.testCode,
     });
 
     clearTimeout(loadTimer);
@@ -166,25 +196,30 @@ const DebugPage: React.FC = () => {
         setOutput((result.payload as { message: string }).message);
         break;
     }
-  }, [testCode, editorRef, setOutput]);
+  }, [debugStates.testCode, editorRef, setOutput]);
 
   const initializeCode = useCallback(() => {
     const editor = editorRef.current as Ace.Editor;
-    editor.setValue(initCode);
+    editor.setValue(debugStates.initCode as string);
     editor.focus();
     editor.clearSelection();
-  }, [initCode]);
+
+    dispatch({
+      type: 'init',
+      payload: { ...debugStates, code: debugStates.initCode },
+    });
+  }, [debugStates]);
 
   const history = useHistory();
   useEffect(() => {
-    console.log(history);
     if (history.location.state) {
-      const code = (history.location.state as { deps?: string })?.deps ?? '';
+      const code =
+        (history.location.state as { deps: { code: string } }).deps.code ?? '';
       if (code) {
-        setCode(code);
+        dispatch({ type: 'setCode', payload: { code } });
       }
     }
-  }, []);
+  }, [history]);
 
   return (
     <EditorPage
@@ -213,7 +248,7 @@ const DebugPage: React.FC = () => {
               theme="twilight"
               name="test"
               fontSize={16}
-              value={code}
+              value={debugStates.code}
               editorProps={{ $blockScrolling: true }}
               setOptions={{
                 tabSize: 2,

--- a/packages/frontend/src/pages/DebugPage/reducer.ts
+++ b/packages/frontend/src/pages/DebugPage/reducer.ts
@@ -1,0 +1,40 @@
+type DebugStates = {
+  content: string;
+  testCode: string[];
+  initCode: string;
+  code: string;
+};
+
+type InitAction = {
+  type: 'init';
+  payload: Omit<DebugStates, 'initCode'>;
+};
+type SetCodeAction = {
+  type: 'setCode';
+  payload: Pick<DebugStates, 'code'>;
+};
+type DebugReducerAction = InitAction | SetCodeAction;
+
+const debugReducer = (
+  state: DebugStates,
+  action: DebugReducerAction,
+): DebugStates => {
+  switch (action.type) {
+    case 'init':
+      return {
+        initCode: action.payload.code,
+        content: state.content || action.payload.content,
+        code: state.code || action.payload.code,
+        testCode: [...action.payload.testCode],
+      };
+    case 'setCode':
+      return {
+        ...state,
+        code: action.payload.code,
+      };
+    default:
+      return state;
+  }
+};
+
+export { debugReducer };

--- a/packages/frontend/src/pages/WritePage/index.tsx
+++ b/packages/frontend/src/pages/WritePage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useContext } from 'react';
+import React, { useEffect, useState, useRef, useCallback, useContext } from 'react';
 import { Editor } from '@toast-ui/react-editor';
 import AceEditor from 'react-ace';
 import { Ace } from 'ace-builds';
@@ -6,6 +6,7 @@ import type { MutableRefObject, RefObject } from 'react';
 import { Redirect, useHistory } from 'react-router-dom';
 
 import { LoginContext } from 'contexts/LoginContext';
+import { useBlockUnload } from 'hooks/useBlockUnload';
 
 import 'ace-builds/src-noconflict/theme-twilight';
 
@@ -62,6 +63,16 @@ const WritePage = () => {
   const [isSubmit, setSubmit] = useState(false);
   const [isSuccess, setSuccess] = useState(false);
   const [isError, setError] = useState(false);
+
+  useBlockUnload(code);
+  useEffect(() => {
+    if (history.location.state) {
+      const code = (history.location.state as { deps?: string })?.deps ?? '';
+      if (code) {
+        setCode(code);
+      }
+    }
+  }, [history]);
 
   const titleInputRef: MutableRefObject<HTMLInputElement | undefined> =
     useRef();
@@ -155,6 +166,7 @@ const WritePage = () => {
                   height="100%"
                   theme="twilight"
                   name="test"
+                  value={code}
                   fontSize={16}
                   editorProps={{ $blockScrolling: true }}
                 />


### PR DESCRIPTION
![Nov-23-2021 13-03-09](https://user-images.githubusercontent.com/9497404/142970207-85209f83-35c6-4d13-980c-de3cdb5d0733.gif)

[history.block](https://v5.reactrouter.com/web/api/history) API도 존재하지만 적용시 popstate를 올바르게 처리하지 못하는 버그가 있어 직접 구현

## 변경 사항
- 페이지 이동 방지 custom hook 추가
- 문제 풀이 페이지 적용
- 문제 출제 페이지 적용