### PR TITLE
fix: 세션 관련 프록시 설정 추가

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -67,6 +67,8 @@ http {
   ##
 
   proxy_set_header X-Forwarded-Proto https;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header Host $host;
 
   server {
     listen 80 default_server;
@@ -91,7 +93,7 @@ http {
     root /var/www/html;
 
     # Add index.php to the list if you are using PHP
-    index index.html index.htm index.nginx-debian.html;
+    index index.html index.htm;
 
     server_name _;
 
@@ -127,8 +129,20 @@ http {
     listen 80;
     server_name ${API_HOST};
 
+    upstream api {
+      server http://localhost:${API_PORT};
+    }
+
     location / {
-      proxy_pass http://localhost:${API_PORT};
+      proxy_pass http://api;
+    }
+
+    location /socket.io/ {
+      proxy_pass http://api;
+
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection upgrade;
     }
   }
 }

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -62,6 +62,12 @@ http {
   #include /etc/nginx/conf.d/*.conf;
   #include /etc/nginx/sites-enabled/*;
 
+  ##
+  # Proxy settings
+  ##
+
+  proxy_set_header X-Forwarded-Proto https;
+
   server {
     listen 80 default_server;
     #listen [::]:80 default_server;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -66,6 +66,31 @@ http {
   # Proxy settings
   ##
 
+  # https://support.cloudflare.com/hc/ko/articles/200170786
+  set_real_ip_from 103.21.244.0/22;
+  set_real_ip_from 103.22.200.0/22;
+  set_real_ip_from 103.31.4.0/22;
+  set_real_ip_from 104.16.0.0/12;
+  set_real_ip_from 108.162.192.0/18;
+  set_real_ip_from 131.0.72.0/22;
+  set_real_ip_from 141.101.64.0/18;
+  set_real_ip_from 162.158.0.0/15;
+  set_real_ip_from 172.64.0.0/13;
+  set_real_ip_from 173.245.48.0/20;
+  set_real_ip_from 188.114.96.0/20;
+  set_real_ip_from 190.93.240.0/20;
+  set_real_ip_from 197.234.240.0/22;
+  set_real_ip_from 198.41.128.0/17;
+  set_real_ip_from 2400:cb00::/32;
+  set_real_ip_from 2606:4700::/32;
+  set_real_ip_from 2803:f800::/32;
+  set_real_ip_from 2405:b500::/32;
+  set_real_ip_from 2405:8100::/32;
+  set_real_ip_from 2c0f:f248::/32;
+  set_real_ip_from 2a06:98c0::/29;
+
+  real_ip_header CF-Connecting-IP;
+
   proxy_set_header X-Forwarded-Proto https;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header Host $host;

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -24,6 +24,10 @@ const origin = new URL(process.env.ORIGIN_URL);
 const getDomainFromHostname = hostname =>
   hostname.split('.').slice(-2).join('.');
 
+if (isProduction) {
+  app.set('trust proxy', 1);
+}
+
 const sessionConfig = session({
   secret: 'GyungGi_FourSkyking',
   store: sessionStore,

--- a/packages/backend/src/settings/socketConfig.ts
+++ b/packages/backend/src/settings/socketConfig.ts
@@ -12,7 +12,11 @@ const getTestCode = async problemId => {
 
 export const socketConnection = (httpServer, sessionConfig) => {
   const io = new Server(httpServer, {
-    cors: { origin: process.env.ORIGIN_URL, credentials: true },
+    cors: {
+      methods: ['GET', 'POST'],
+      origin: process.env.ORIGIN_URL,
+      credentials: true,
+    },
   });
 
   io.use((socket, next) => {

--- a/packages/frontend/src/contexts/SocketContext.ts
+++ b/packages/frontend/src/contexts/SocketContext.ts
@@ -1,5 +1,6 @@
 import React from 'react';
-import io, { Socket } from 'socket.io-client';
+import io from 'socket.io-client';
+import type { Socket } from 'socket.io-client';
 import { DefaultEventsMap } from '@socket.io/component-emitter';
 
 const socket: Socket<DefaultEventsMap, DefaultEventsMap> = io(


### PR DESCRIPTION
## 변경 사항
백엔드 리버스 프록시 관련 GitHub OAuth 로그인, 소켓 세션 인증, `Set-Cookie` 세션 설정 헤더 등의 문제를 해결

## 참고
- https://expressjs.com/ko/4x/api.html#app.set
- https://www.npmjs.com/package/express-session#user-content-cookiesecure
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
- https://socket.io/docs/v4/reverse-proxy/
- https://support.cloudflare.com/hc/ko/articles/200170786