### PR TITLE
fix: 잘못된 Nginx 설정 문법 수정

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -149,21 +149,21 @@ http {
     #}
   }
 
+  upstream backend {
+    server 127.0.0.1:${API_PORT};
+  }
+
   # API Server
   server {
     listen 80;
     server_name ${API_HOST};
 
-    upstream api {
-      server http://localhost:${API_PORT};
-    }
-
     location / {
-      proxy_pass http://api;
+      proxy_pass http://backend;
     }
 
     location /socket.io/ {
-      proxy_pass http://api;
+      proxy_pass http://backend;
 
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
잘못된 upstream 블럭 위치로 인해 발생하는 오류를 수정

참고: https://nginx.org/en/docs/http/ngx_http_upstream_module.html