### PR TITLE
feat: 제출 버튼을 눌렀을때 이동 방지를 해제하도록 수정

### DIFF
--- a/packages/frontend/src/pages/DebugPage/index.tsx
+++ b/packages/frontend/src/pages/DebugPage/index.tsx
@@ -76,7 +76,8 @@ const DebugPage: React.FC = () => {
   const [isError, setError] = useState(false);
   const history = useHistory();
 
-  useBlockUnload(debugStates, (_, deps) => {
+  const unblockRef = useRef(false);
+  useBlockUnload(debugStates, unblockRef, (_, deps) => {
     return deps.initCode !== deps.code;
   });
 
@@ -137,6 +138,7 @@ const DebugPage: React.FC = () => {
   );
 
   const onSubmit = useCallback(async () => {
+    unblockRef.current = true;
     history.push('/result', {
       code: (editorRef.current as Ace.Editor).getValue() as string,
       testCode: debugStates.testCode,

--- a/packages/frontend/src/pages/WritePage/index.tsx
+++ b/packages/frontend/src/pages/WritePage/index.tsx
@@ -155,7 +155,9 @@ const WritePage = () => {
   const [isValidLang, setValidLang] = useState(false);
   const [validationMessages, setValidationMessages] = useState<string[]>([]);
 
-  useBlockUnload(code);
+  const unblockRef = useRef(false);
+  useBlockUnload(code, unblockRef);
+
   useEffect(() => {
     if (history.location.state) {
       const code = (history.location.state as { deps?: string })?.deps ?? '';
@@ -266,6 +268,7 @@ const WritePage = () => {
       setLoading(false);
       if (res.status === 201) {
         setSuccess(true);
+        unblockRef.current = true;
         setTimeout(() => {
           history.push('/');
         }, 2000);


### PR DESCRIPTION
- 문제 풀이 및 출제 페이지에서 코드를 변경한 후, 제출 버튼을 눌러도 페이지 이동 `confirm` 창이 나오지 않도록 수정