### PR TITLE
chore!: 프론트엔드 테스트로직 제거 및 콘솔 출력 구현

### DIFF
--- a/packages/frontend/src/pages/DebugPage/debug.ts
+++ b/packages/frontend/src/pages/DebugPage/debug.ts
@@ -48,16 +48,11 @@ function execCodeWithSandbox(
           <meta charset="utf-8">
           <meta
             http-equiv="content-security-policy"
-            content="script-src https://cdn.jsdelivr.net blob: 'unsafe-inline' 'unsafe-eval';">
+            content="script-src blob: 'unsafe-inline' 'unsafe-eval';">
         </head>
         <body>
           <script>
-            (${sandboxFunction})(
-              \`${code}\`,
-              ${JSON.stringify(testCodes)},
-              \`${setup}\`,
-              (${execCodeWithWorker}),
-              \`${window.origin}\`);
+            (${sandboxFunction})(\`${code}\`, (${execCodeWithWorker}), \`${window.origin}\`);
           </script>
         </body>
       </html>

--- a/packages/frontend/src/pages/DebugPage/index.tsx
+++ b/packages/frontend/src/pages/DebugPage/index.tsx
@@ -54,6 +54,16 @@ const ConsoleWrapper = styled.div`
   color: white;
 `;
 
+const Console = styled.textarea`
+  color: white;
+  width: 100%;
+  height: 100%;
+  padding: 15px;
+  background-color: transparent;
+  border: 0;
+  resize: none;
+`;
+
 const ButtonFooter = styled.div`
   display: flex;
   flex-basis: 0;
@@ -144,28 +154,50 @@ const DebugPage: React.FC = () => {
     });
   }, [debugStates.testCode, history, id]);
 
-  const onExecute = useCallback(async () => {
+  const onExecute = useCallback(() => {
+    console.clear();
+    setOutput('');
+    const logConsole = (message: string) =>
+      setOutput(prev => `${prev}\n${message}`.trim());
+
+    logConsole('[실행 시작...]');
+
+    const startTime = Date.now();
+    const dispatcher = runner(
+      (editorRef.current as Ace.Editor).getValue() as string,
+    );
+
     const loadTimer = setTimeout(() => {
       setLoading(true);
     }, 500);
 
-    const result = await runner({
-      code: (editorRef.current as Ace.Editor).getValue() as string,
-      testCode: debugStates.testCode,
+    const timeout = 5 * 1000;
+    const killTimer = setTimeout(() => {
+      logConsole('TimeoutError: timeout 5s');
+      dispatcher.dispatchEvent(new CustomEvent('kill'));
+    }, timeout);
+
+    dispatcher.addEventListener('stdout', (event: CustomEventInit) => {
+      logConsole(event.detail);
     });
+    dispatcher.addEventListener('stderr', (event: CustomEventInit) => {
+      logConsole(event.detail);
+    });
+    dispatcher.addEventListener(
+      'exit',
+      (event: CustomEventInit) => {
+        clearTimeout(killTimer);
+        clearTimeout(loadTimer);
+        setLoading(false);
 
-    clearTimeout(loadTimer);
-    setLoading(false);
-
-    switch (result.type) {
-      case 'success':
-        setOutput('축하합니다. 멋지게 해내셨네요! 🥳');
-        break;
-      case 'error':
-        setOutput((result.payload as { message: string }).message);
-        break;
-    }
-  }, [debugStates.testCode, editorRef, setOutput]);
+        const endTime = Date.now();
+        setOutput(prev =>
+          `${prev}\n\n[실행 완료: ${endTime - startTime}ms]`.trim(),
+        );
+      },
+      { once: true },
+    );
+  }, []);
 
   const initializeCode = useCallback(() => {
     const editor = editorRef.current as Ace.Editor;
@@ -200,7 +232,7 @@ const DebugPage: React.FC = () => {
             />
           </ViewerWrapper>
           <ConsoleWrapper>
-            <div>{output}</div>
+            <Console value={output} readOnly />
           </ConsoleWrapper>
         </>
       }

--- a/packages/frontend/src/pages/DebugPage/sandbox.js
+++ b/packages/frontend/src/pages/DebugPage/sandbox.js
@@ -1,4 +1,4 @@
-export function sandboxFunction(code, testCodes, setup, exec, origin) {
+export function sandboxFunction(code, exec, origin) {
   var postMessage;
   window.onmessage = function (message) {
     if (message.origin === origin && message.ports) {
@@ -8,7 +8,7 @@ export function sandboxFunction(code, testCodes, setup, exec, origin) {
         port2.postMessage(data);
       };
 
-      exec(code, testCodes, setup || '')
+      exec(code)
         .then(payload => postMessage({ type: 'success', payload }))
         .catch(err => postMessage({ type: 'error', payload: err }));
     }

--- a/packages/frontend/src/pages/DebugPage/worker.js
+++ b/packages/frontend/src/pages/DebugPage/worker.js
@@ -1,84 +1,105 @@
-export function execCodeWithWorker(code, testCodes, setup) {
-  return new Promise((resolve, reject) => {
-    function codeToUrl(code) {
-      const blob = new Blob(['(' + String(code) + ')()'], {
-        type: 'text/javascript',
-      });
-      return URL.createObjectURL(blob);
-    }
+export function execCodeWithWorker(code) {
+  function codeToUrl(code) {
+    const blob = new Blob(['(' + String(code) + ')()'], {
+      type: 'text/javascript',
+    });
+    return URL.createObjectURL(blob);
+  }
 
-    const random = Math.random().toString(32).substring(2);
-    const worker = new Worker(
-      codeToUrl(`
-        function () {
-          // 특정 메소드를 사용자 접근 불가하도록 제거
-          delete WorkerGlobalScope.prototype.importScripts;
-          delete WorkerGlobalScope.prototype.fetch;
-          delete self.close;
+  const random = Math.random().toString(32).substring(2);
+  const worker = new Worker(
+    codeToUrl(`
+      function () {
+        // 특정 메소드를 사용자 접근 불가하도록 제거
+        delete WorkerGlobalScope.prototype.importScripts;
+        delete WorkerGlobalScope.prototype.fetch;
+        delete self.close;
 
-          // 제거한 prototype을 수정 불가하도록 변경
-          Object.freeze(WorkerGlobalScope.prototype);
+        // 제거한 prototype을 수정 불가하도록 변경
+        Object.freeze(WorkerGlobalScope.prototype);
 
-          onmessage = function (message) {
-            try {
-              // 문법검사
-              new Function(message.data);
+        onmessage = function (message) {
+          try {
+            // 문법검사
+            new Function(message.data);
 
-              const func = new Function('$$__cyfm__${random},console', \`
-                \${message.data}
-                return $$__cyfm__${random};
-              \`);
-              const key = func('${random}', console);
+            const func = new Function(
+              '$$__cyfm__${random}, ' +
+              'console, ' +
+              'postMessage, ' +
+              'self, ' +
+              'globalThis', \`
+              \${message.data}
+              return $$__cyfm__${random};
+            \`);
+            const key = func.call(
+              {},  /* Context */
+              '${random}',  /* Key */
+              Object.freeze({  /* Console mock */
+                log: function () {
+                  postMessage({
+                    key: '${random}',
+                    type: 'stdout',
+                    payload: [].slice.call(arguments).join(' '),
+                  });
+                  console.log.apply(null, arguments);
+                },
+              }),
+              undefined,  /* postMessage */
+              {},  /* self */
+              {}  /* globalThis */
+            );
 
-              postMessage(
-                JSON.stringify({
-                  key: key,
-                  type: 'success'
-                })
-              );
-            } catch (e) {
-              postMessage(
-                JSON.stringify({
-                  key: '${random}',
-                  type: 'error',
-                  result: {
-                    message: e instanceof Error ? e.message : e
-                  }
-                })
-              );
-            }
-          };
-        }
-      `),
-    );
-
-    const timeout = 5;
-    const timer = setTimeout(() => {
-      worker.terminate();
-      reject({
-        message: `timeout ${timeout}s`,
-      });
-    }, 1000 * timeout);
-
-    worker.onmessage = function (message) {
-      clearTimeout(timer);
-      try {
-        const parsedMessage = JSON.parse(message.data);
-        if (parsedMessage.key === random) {
-          if (parsedMessage.type === 'success') {
-            resolve(parsedMessage.result);
-          } else if (parsedMessage.type === 'error') {
-            reject(parsedMessage.result);
+            postMessage({
+              key: key,
+              type: 'done',
+            });
+          } catch (e) {
+            postMessage({
+              key: '${random}',
+              type: 'error',
+              payload: e.stack || e.message || 'Uncaught: ' + String(e),
+            });
           }
-        } else {
-          reject({
-            message: `Illegal return statement`,
-          });
-        }
-      } catch (e) {
-        reject(e);
+        };
       }
-    };
-    worker.postMessage(code);
+    `),
+  );
+  const process = new EventTarget();
+  worker.addEventListener('message', function (event) {
+    const message = event.data;
+    try {
+      if (message.key !== random) {
+        throw new SyntaxError(`Illegal return statement`);
+      }
+      switch (message.type) {
+        case 'stdout':
+          process.dispatchEvent(
+            new CustomEvent('stdout', { detail: message.payload }),
+          );
+          break;
+        case 'error':
+          process.dispatchEvent(
+            new CustomEvent('error', { detail: message.payload }),
+          );
+          break;
+        case 'done':
+          process.dispatchEvent(new CustomEvent('exit', { detail: 0 }));
+        /* eslint-disable-next-line no-fallthrough */
+        default:
+          worker.terminate();
+          break;
+      }
+    } catch (e) {
+      process.dispatchEvent(
+        new CustomEvent('error', { detail: e.stack || e.message }),
+      );
+    }
   });
+  process.kill = function (exitCode) {
+    worker.terminate();
+    process.dispatchEvent(new CustomEvent('exit', { detail: exitCode || -1 }));
+  };
+  worker.postMessage(code);
+  return process;
 }

--- a/packages/frontend/src/pages/DebugPage/worker.js
+++ b/packages/frontend/src/pages/DebugPage/worker.js
@@ -1,8 +1,4 @@
 export function execCodeWithWorker(code, testCodes, setup) {
-  function escapeTemplate(code) {
-    return code.replaceAll(/([\\$`])/g, '\\$1');
-  }
-
   return new Promise((resolve, reject) => {
     function codeToUrl(code) {
       const blob = new Blob(['(' + String(code) + ')()'], {
@@ -11,88 +7,78 @@ export function execCodeWithWorker(code, testCodes, setup) {
       return URL.createObjectURL(blob);
     }
 
-    const testPromises = testCodes.map(testCode => {
-      const random = Math.random().toString(32).substring(2);
-      const worker = new Worker(
-        codeToUrl(`
-          function () {
-            importScripts('https://cdn.jsdelivr.net/npm/chai@4.3.4/chai.js');
+    const random = Math.random().toString(32).substring(2);
+    const worker = new Worker(
+      codeToUrl(`
+        function () {
+          // 특정 메소드를 사용자 접근 불가하도록 제거
+          delete WorkerGlobalScope.prototype.importScripts;
+          delete WorkerGlobalScope.prototype.fetch;
+          delete self.close;
 
-            // 특정 메소드를 사용자 접근 불가하도록 제거
-            delete WorkerGlobalScope.prototype.importScripts;
-            delete WorkerGlobalScope.prototype.fetch;
-            delete self.close;
+          // 제거한 prototype을 수정 불가하도록 변경
+          Object.freeze(WorkerGlobalScope.prototype);
 
-            // 제거한 prototype을 수정 불가하도록 변경
-            Object.freeze(WorkerGlobalScope.prototype);
+          onmessage = function (message) {
+            try {
+              // 문법검사
+              new Function(message.data);
 
-            onmessage = function (message) {
-              try {
-                // 문법검사
-                new Function(\`${escapeTemplate(code)}\`);
+              const func = new Function('$$__cyfm__${random},console', \`
+                \${message.data}
+                return $$__cyfm__${random};
+              \`);
+              const key = func('${random}', console);
 
-                const func = new Function('$$__cyfm__${random}', \`
-                  ${escapeTemplate(setup)}
-                  ${escapeTemplate(code)}
-                  \${message.data}
-                  return $$__cyfm__${random};
-                \`);
-                const key = func('${random}');
-
-                postMessage(
-                  JSON.stringify({
-                    key: key,
-                    type: 'success'
-                  })
-                );
-              } catch (e) {
-                postMessage(
-                  JSON.stringify({
-                    key: '${random}',
-                    type: 'error',
-                    result: {
-                      message: e instanceof Error ? e.message : e
-                    }
-                  })
-                );
-              }
-            };
-          }
-        `),
-      );
-
-      return new Promise((resolve, reject) => {
-        const timeout = 5;
-        const timer = setTimeout(() => {
-          worker.terminate();
-          reject({
-            message: `timeout ${timeout}s`,
-          });
-        }, 1000 * timeout);
-
-        worker.onmessage = function (message) {
-          clearTimeout(timer);
-          try {
-            const parsedMessage = JSON.parse(message.data);
-            if (parsedMessage.key === random) {
-              if (parsedMessage.type === 'success') {
-                resolve(parsedMessage.result);
-              } else if (parsedMessage.type === 'error') {
-                reject(parsedMessage.result);
-              }
-            } else {
-              reject({
-                message: `Illegal return statement`,
-              });
+              postMessage(
+                JSON.stringify({
+                  key: key,
+                  type: 'success'
+                })
+              );
+            } catch (e) {
+              postMessage(
+                JSON.stringify({
+                  key: '${random}',
+                  type: 'error',
+                  result: {
+                    message: e instanceof Error ? e.message : e
+                  }
+                })
+              );
             }
-          } catch (e) {
-            reject(e);
-          }
-        };
-        worker.postMessage(testCode);
-      });
-    });
+          };
+        }
+      `),
+    );
 
-    Promise.all(testPromises).then(resolve).catch(reject);
+    const timeout = 5;
+    const timer = setTimeout(() => {
+      worker.terminate();
+      reject({
+        message: `timeout ${timeout}s`,
+      });
+    }, 1000 * timeout);
+
+    worker.onmessage = function (message) {
+      clearTimeout(timer);
+      try {
+        const parsedMessage = JSON.parse(message.data);
+        if (parsedMessage.key === random) {
+          if (parsedMessage.type === 'success') {
+            resolve(parsedMessage.result);
+          } else if (parsedMessage.type === 'error') {
+            reject(parsedMessage.result);
+          }
+        } else {
+          reject({
+            message: `Illegal return statement`,
+          });
+        }
+      } catch (e) {
+        reject(e);
+      }
+    };
+    worker.postMessage(code);
   });
 }


### PR DESCRIPTION

![Screen Shot 2021-11-26 at 12 45 28 AM](https://user-images.githubusercontent.com/9497404/143470646-2425bb09-5e6e-477b-9035-135076bd7ff1.png)


BREAKING CHANGE:
- 백엔드로의 테스트 로직 이주의 후속으로 프론트엔드 테스트 로직 제거
- 컴포넌트의 `console.log` 렌더링 기능을 mocking으로 구현