### PR TITLE
refactor: 상수 및 메세지를 페이지 파일로부터 분리

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -109,13 +109,13 @@ const App: React.FC = () => {
         <ConfirmModal
           isOpen={isLogoutOpen}
           setter={setLogoutOpen}
-          messages={['로그아웃 하시겠습니까?']}
+          message={'로그아웃 하시겠습니까?'}
           callback={logout}
         />
         <MessageModal
           isOpen={isMessageOpen}
           setter={setMessageOpen}
-          messages={['비정상적인 접근입니다.', '로그인 상태를 확인해주세요.']}
+          message={'비정상적인 접근입니다.\n로그인 상태를 확인해주세요.'}
           close={true}
         />
         <LoginContext.Provider value={login}>

--- a/packages/frontend/src/components/Modal/ConfirmModal.tsx
+++ b/packages/frontend/src/components/Modal/ConfirmModal.tsx
@@ -9,7 +9,7 @@ import Button from './ModalButton';
 interface ModalProps {
   isOpen: boolean;
   setter: (isOpen: boolean) => void;
-  messages: string[];
+  message: string;
   callback: () => void;
 }
 
@@ -34,14 +34,14 @@ const ButtonWrapper = styled.div`
 `;
 
 const ConfirmModal = (props: ModalProps) => {
-  const { isOpen, setter, messages, callback } = props;
+  const { isOpen, setter, message, callback } = props;
 
   const closeModal = () => setter(false);
   return (
     <Modal isOpen={isOpen} setter={setter}>
       <ContentWrapper>
-        {messages.map(message => (
-          <MessageWrapper key={nanoid()}>{message}</MessageWrapper>
+        {message.split('\n').map(line => (
+          <MessageWrapper key={nanoid()}>{line}</MessageWrapper>
         ))}
       </ContentWrapper>
       <ButtonWrapper>

--- a/packages/frontend/src/components/Modal/MessageModal.tsx
+++ b/packages/frontend/src/components/Modal/MessageModal.tsx
@@ -9,7 +9,7 @@ import Button from './ModalButton';
 interface ModalProps {
   isOpen: boolean;
   setter: (isOpen: boolean) => void;
-  messages: string[];
+  message: string;
   close?: boolean;
 }
 
@@ -34,14 +34,14 @@ const ButtonWrapper = styled.div`
 `;
 
 const MessageModal = (props: ModalProps) => {
-  const { isOpen, setter, messages } = props;
+  const { isOpen, setter, message } = props;
 
   const closeModal = () => setter(false);
   return (
     <Modal isOpen={isOpen} setter={setter}>
       <ContentWrapper>
-        {messages.map(message => (
-          <MessageWrapper key={nanoid()}>{message}</MessageWrapper>
+        {message.split('\n').map(line => (
+          <MessageWrapper key={nanoid()}>{line}</MessageWrapper>
         ))}
       </ContentWrapper>
       {props.close ? (

--- a/packages/frontend/src/components/TestCodeEditor.tsx
+++ b/packages/frontend/src/components/TestCodeEditor.tsx
@@ -55,18 +55,18 @@ const TestCodeEditor = ({
   setTestCases: React.Dispatch<React.SetStateAction<TestCase[]>>;
 }) => {
   const [isMessage, setMessage] = useState(false);
-  const [messages, setMessages] = useState<string[]>([]);
+  const [messages, setMessages] = useState<string>('');
   const titleRef: MutableRefObject<HTMLInputElement | undefined> = useRef();
   const codeRef: MutableRefObject<HTMLInputElement | undefined> = useRef();
 
   const inputValidation = (title: string, code: string) => {
     if (title.length === 0) {
-      setMessages(['테스트케이스 제목을 입력해주세요.']);
+      setMessages('테스트케이스 제목을 입력해주세요.');
       return false;
     }
 
     if (code.length === 0) {
-      setMessages(['테스트케이스 코드를 입력해주세요.']);
+      setMessages('테스트케이스 코드를 입력해주세요.');
       return false;
     }
 
@@ -106,7 +106,7 @@ const TestCodeEditor = ({
       <MessageModal
         isOpen={isMessage}
         setter={setMessage}
-        messages={messages}
+        message={messages}
         close={true}
       />
       <TestCodeViewer testCases={testCases} remove={remove} />

--- a/packages/frontend/src/pages/DebugPage/index.tsx
+++ b/packages/frontend/src/pages/DebugPage/index.tsx
@@ -27,7 +27,6 @@ import Button from 'components/Button';
 import Console from 'components/Console';
 import { LoginContext } from 'contexts/LoginContext';
 import MessageModal from 'components/Modal/MessageModal';
-import ConfirmModal from 'components/Modal/ConfirmModal';
 import LoadingModal from 'components/Modal/LoadingModal';
 
 import { useSandbox } from 'hooks/useSandbox';
@@ -38,6 +37,11 @@ import 'ace-builds/src-noconflict/mode-javascript';
 import 'ace-builds/src-noconflict/theme-twilight';
 import '@toast-ui/editor/dist/toastui-editor.css';
 import '@toast-ui/editor/dist/theme/toastui-editor-dark.css';
+import {
+  LOGIN_VALIDATION_FAIL_MESSAGE,
+  SUBMIT_FAIL_MESSAGE,
+  TIMEOUT_MESSAGE,
+} from './message';
 
 const ViewerWrapper = styled.div`
   display: flex;
@@ -75,8 +79,6 @@ const DebugPage: React.FC = () => {
   const { isLogin } = useContext(LoginContext);
   const [output, setOutput] = useState('');
   const [isLoading, setLoading] = useState(false);
-  const [isSuccess, setSuccess] = useState(false);
-  const [isFail, setFail] = useState(false);
   const [isTimeover, setTimeover] = useState(false);
   const [isError, setError] = useState(false);
   const [isLoginCheck, setLoginCheck] = useState(false);
@@ -269,36 +271,22 @@ const DebugPage: React.FC = () => {
             <Button onClick={onSubmit}>제출</Button>
           </ButtonFooter>
           <LoadingModal isOpen={isLoading} />
-          <ConfirmModal
-            isOpen={isSuccess}
-            setter={setSuccess}
-            messages={['정답입니다!', '다른 문제를 풀러 가시겠습니까?']}
-            callback={() => {
-              history.push('/');
-            }}
-          />
-          <MessageModal
-            isOpen={isFail}
-            setter={setFail}
-            messages={['틀렸습니다.', '다시 도전해 보세요!']}
-            close={true}
-          />
           <MessageModal
             isOpen={isTimeover}
             setter={setTimeover}
-            messages={['실행 시간이 5초를 초과했습니다.']}
+            message={TIMEOUT_MESSAGE}
             close={true}
           />
           <MessageModal
             isOpen={isError}
             setter={setError}
-            messages={['제출에 실패했습니다.', '담당자에게 문의 바랍니다.']}
+            message={SUBMIT_FAIL_MESSAGE}
             close={true}
           />
           <MessageModal
             isOpen={isLoginCheck}
             setter={setLoginCheck}
-            messages={['문제 풀이 제출을 위해서는', '로그인이 필요합니다.']}
+            message={LOGIN_VALIDATION_FAIL_MESSAGE}
             close={true}
           />
         </>

--- a/packages/frontend/src/pages/DebugPage/message.ts
+++ b/packages/frontend/src/pages/DebugPage/message.ts
@@ -1,0 +1,7 @@
+export const TIMEOUT_MESSAGE = '실행 시간이 5초를 초과했습니다.';
+
+export const SUBMIT_FAIL_MESSAGE =
+  '제출에 실패했습니다.\n담당자에게 문의 바랍니다.';
+
+export const LOGIN_VALIDATION_FAIL_MESSAGE =
+  '문제 풀이 제출을 위해서는\n로그인이 필요합니다.';

--- a/packages/frontend/src/pages/WritePage/constant.ts
+++ b/packages/frontend/src/pages/WritePage/constant.ts
@@ -1,13 +1,3 @@
-export const VALIDATION_FAIL_MESSAGE = {
-  title: ['제목이 입력되지 않았습니다.', '제목을 입력해주세요.'],
-  markdown: ['문제가 입력되지 않았습니다.', '문제를 입력해주세요.'],
-  code: ['코드가 입력되지 않았습니다.', '코드를 입력해주세요.'],
-  testcase: [
-    '테스트 케이스가 입력되지 않았습니다.',
-    '테스트 케이스를 입력해주세요.',
-  ],
-};
-
 export const LANGUAGE_SELECTIONS = ['C++', 'Java', 'JavaScript', 'Python'];
 
 export const VALID_LANGUAGES = ['JavaScript'];

--- a/packages/frontend/src/pages/WritePage/index.tsx
+++ b/packages/frontend/src/pages/WritePage/index.tsx
@@ -17,11 +17,14 @@ import { Redirect, useHistory } from 'react-router-dom';
 import { LoginContext } from 'contexts/LoginContext';
 import { useSandbox } from 'hooks/useSandbox';
 import { useBlockUnload } from 'hooks/useBlockUnload';
+import { LANGUAGE_SELECTIONS, VALID_LANGUAGES } from './constant';
 import {
   VALIDATION_FAIL_MESSAGE,
-  LANGUAGE_SELECTIONS,
-  VALID_LANGUAGES,
-} from './constant';
+  CHECK_BEFORE_SUBMIT_MESSAGE,
+  CHECK_IS_VALID_LANGUAGE,
+  SUBMIT_SUCCESS_MESSAGE,
+  SUBMIT_FAIL_MESSAGE,
+} from './message';
 
 import 'ace-builds/src-noconflict/theme-twilight';
 import 'ace-builds/src-noconflict/mode-c_cpp';
@@ -160,7 +163,7 @@ const WritePage = () => {
   const [isError, setError] = useState(false);
   const [isValid, setValid] = useState(false);
   const [isValidLang, setValidLang] = useState(false);
-  const [validationMessages, setValidationMessages] = useState<string[]>([]);
+  const [validationMessages, setValidationMessages] = useState<string>('');
 
   const unblockRef = useRef(false);
   useBlockUnload(code, unblockRef);
@@ -444,11 +447,7 @@ const WritePage = () => {
               <ConfirmModal
                 isOpen={isSubmit}
                 setter={setSubmit}
-                messages={[
-                  '제출 후에는 내용을',
-                  '변경할 수 없습니다.',
-                  '정말로 제출하시겠습니까?',
-                ]}
+                message={CHECK_BEFORE_SUBMIT_MESSAGE}
                 callback={() => {
                   setSubmit(false);
                   onSubmit();
@@ -457,32 +456,25 @@ const WritePage = () => {
               <MessageModal
                 isOpen={isValid}
                 setter={setValid}
-                messages={validationMessages}
+                message={validationMessages}
                 close={true}
               />
               <MessageModal
                 isOpen={isValidLang}
                 setter={setValidLang}
-                messages={[
-                  '현재는 지원하지 않는 언어입니다.',
-                  '빠른 시일 내에 지원하겠습니다.',
-                  '현재 사용 가능 언어 : JavaScript',
-                ]}
+                message={CHECK_IS_VALID_LANGUAGE}
                 close={true}
               />
               <MessageModal
                 isOpen={isSuccess}
                 setter={setSuccess}
-                messages={[
-                  '문제 제출에 성공했습니다.',
-                  '잠시 후 문제 리스트로 이동합니다.',
-                ]}
+                message={SUBMIT_SUCCESS_MESSAGE}
                 close={false}
               />
               <MessageModal
                 isOpen={isError}
                 setter={setError}
-                messages={['출제에 실패했습니다.', '담당자에게 문의 바랍니다.']}
+                message={SUBMIT_FAIL_MESSAGE}
                 close={true}
               />
             </>

--- a/packages/frontend/src/pages/WritePage/message.ts
+++ b/packages/frontend/src/pages/WritePage/message.ts
@@ -1,0 +1,22 @@
+import { VALID_LANGUAGES } from './constant';
+
+export const VALIDATION_FAIL_MESSAGE = {
+  title: '제목이 입력되지 않았습니다. \n 제목을 입력해주세요.',
+  markdown: '문제가 입력되지 않았습니다.\n문제를 입력해주세요.',
+  code: '코드가 입력되지 않았습니다.\n코드를 입력해주세요.',
+  testcase:
+    '테스트 케이스가 입력되지 않았습니다.\n테스트 케이스를 입력해주세요.',
+};
+
+export const CHECK_BEFORE_SUBMIT_MESSAGE =
+  '제출 후에는 내용을\n변경할 수 없습니다.\n정말로 제출하시겠습니까?';
+
+export const CHECK_IS_VALID_LANGUAGE = `현재는 지원하지 않는 언어입니다.\n빠른 시일 내에 지원하겠습니다.\n현재 사용 가능 언어 : ${VALID_LANGUAGES.join(
+  ', ',
+)}`;
+
+export const SUBMIT_SUCCESS_MESSAGE =
+  '문제 제출에 성공했습니다.\n잠시 후 문제 리스트로 이동합니다.';
+
+export const SUBMIT_FAIL_MESSAGE =
+  '출제에 실패했습니다.\n담당자에게 문의 바랍니다.';


### PR DESCRIPTION
**작업 목록**
- `message` props를 리스트에서 문자열로 변경
- 문제 풀이 페이지의 메세지를 별도의 파일로 분리
- 문제 출제 페이지의 상수와 메세지를 별도의 파일로 분리