### PR TITLE
refactor: Modal 상태 관리를 Reducer로 수정

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -72,25 +72,14 @@ const App: React.FC = () => {
 
   const [modalStates, dispatch] = useReducer(
     (state: ModalState, action: ModalReducerAction): ModalState => {
-      switch (action.type) {
-        case 'open':
-          switch (action.payload.target) {
-            case 'logout':
-              return { ...state, openLogout: true };
-            case 'message':
-              return { ...state, openMessage: true };
-            default:
-              return state;
-          }
-        case 'close':
-          switch (action.payload.target) {
-            case 'logout':
-              return { ...state, openLogout: false };
-            case 'message':
-              return { ...state, openMessage: false };
-            default:
-              return state;
-          }
+      const isOpen = action.type === 'open';
+      switch (action.payload.target) {
+        case 'logout':
+          return { ...state, openLogout: isOpen };
+        case 'message':
+          return { ...state, openMessage: isOpen };
+        default:
+          return state;
       }
     },
     {

--- a/packages/frontend/src/components/Modal/ConfirmModal.tsx
+++ b/packages/frontend/src/components/Modal/ConfirmModal.tsx
@@ -3,12 +3,15 @@ import { nanoid } from 'nanoid';
 
 import styled from '@cyfm/styled';
 
+import { ModalReducerAction } from './ModalType';
+
 import Modal from './Modal';
 import Button from './ModalButton';
 
 interface ModalProps {
   isOpen: boolean;
-  setter: (isOpen: boolean) => void;
+  setter: React.Dispatch<ModalReducerAction>;
+  target: string;
   message: string;
   callback: () => void;
 }
@@ -34,11 +37,17 @@ const ButtonWrapper = styled.div`
 `;
 
 const ConfirmModal = (props: ModalProps) => {
-  const { isOpen, setter, message, callback } = props;
+  const { isOpen, setter, target, message, callback } = props;
 
-  const closeModal = () => setter(false);
+  const closeModal = () =>
+    setter({
+      type: 'close',
+      payload: {
+        target: target,
+      },
+    });
   return (
-    <Modal isOpen={isOpen} setter={setter}>
+    <Modal isOpen={isOpen} setter={setter} target={target}>
       <ContentWrapper>
         {message.split('\n').map(line => (
           <MessageWrapper key={nanoid()}>{line}</MessageWrapper>

--- a/packages/frontend/src/components/Modal/ConfirmModal.tsx
+++ b/packages/frontend/src/components/Modal/ConfirmModal.tsx
@@ -3,15 +3,12 @@ import { nanoid } from 'nanoid';
 
 import styled from '@cyfm/styled';
 
-import { ModalReducerAction } from './ModalType';
-
 import Modal from './Modal';
 import Button from './ModalButton';
 
-interface ModalProps {
-  isOpen: boolean;
-  setter: React.Dispatch<ModalReducerAction>;
-  target: string;
+import type { ModalBaseProps } from './ModalType';
+
+interface ModalProps extends ModalBaseProps {
   message: string;
   callback: () => void;
 }

--- a/packages/frontend/src/components/Modal/GuideModal.tsx
+++ b/packages/frontend/src/components/Modal/GuideModal.tsx
@@ -4,15 +4,15 @@ import { nanoid } from 'nanoid';
 
 import styled from '@cyfm/styled';
 
-import Button from './ModalButton';
-
 import TESTCASES from './GuidelineCase';
 
-interface ModalProps {
-  isOpen: boolean;
+import Button from './ModalButton';
+import type { ModalBaseProps } from './ModalType';
+
+type ModalProps = ModalBaseProps & {
   setter: (isOpen: boolean) => void;
   close?: boolean;
-}
+};
 
 const ModalWrapper = styled.div`
   display: flex;

--- a/packages/frontend/src/components/Modal/MessageModal.tsx
+++ b/packages/frontend/src/components/Modal/MessageModal.tsx
@@ -3,15 +3,12 @@ import { nanoid } from 'nanoid';
 
 import styled from '@cyfm/styled';
 
-import { ModalReducerAction } from './ModalType';
-
 import Modal from './Modal';
 import Button from './ModalButton';
 
-interface ModalProps {
-  isOpen: boolean;
-  setter: React.Dispatch<ModalReducerAction>;
-  target: string;
+import type { ModalBaseProps } from './ModalType';
+
+interface ModalProps extends ModalBaseProps {
   message: string;
   close?: boolean;
 }

--- a/packages/frontend/src/components/Modal/MessageModal.tsx
+++ b/packages/frontend/src/components/Modal/MessageModal.tsx
@@ -3,12 +3,15 @@ import { nanoid } from 'nanoid';
 
 import styled from '@cyfm/styled';
 
+import { ModalReducerAction } from './ModalType';
+
 import Modal from './Modal';
 import Button from './ModalButton';
 
 interface ModalProps {
   isOpen: boolean;
-  setter: (isOpen: boolean) => void;
+  setter: React.Dispatch<ModalReducerAction>;
+  target: string;
   message: string;
   close?: boolean;
 }
@@ -34,11 +37,17 @@ const ButtonWrapper = styled.div`
 `;
 
 const MessageModal = (props: ModalProps) => {
-  const { isOpen, setter, message } = props;
+  const { isOpen, setter, target, message } = props;
 
-  const closeModal = () => setter(false);
+  const closeModal = () =>
+    setter({
+      type: 'close',
+      payload: {
+        target: target,
+      },
+    });
   return (
-    <Modal isOpen={isOpen} setter={setter}>
+    <Modal isOpen={isOpen} setter={setter} target={target}>
       <ContentWrapper>
         {message.split('\n').map(line => (
           <MessageWrapper key={nanoid()}>{line}</MessageWrapper>

--- a/packages/frontend/src/components/Modal/Modal.tsx
+++ b/packages/frontend/src/components/Modal/Modal.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import Modal from 'react-modal';
 
-import { ModalReducerAction } from './ModalType';
+import type { ModalBaseProps } from './ModalType';
 
-interface ModalProps {
-  isOpen: boolean;
-  setter: React.Dispatch<ModalReducerAction>;
-  target: string;
+interface ModalProps extends ModalBaseProps {
   children: React.ReactNode;
 }
 

--- a/packages/frontend/src/components/Modal/Modal.tsx
+++ b/packages/frontend/src/components/Modal/Modal.tsx
@@ -1,18 +1,29 @@
 import React from 'react';
 import Modal from 'react-modal';
 
+import { ModalReducerAction } from './ModalType';
+
 interface ModalProps {
   isOpen: boolean;
-  setter: (isOpen: boolean) => void;
+  setter: React.Dispatch<ModalReducerAction>;
+  target: string;
   children: React.ReactNode;
 }
 
 const CustomModal = (props: ModalProps) => {
-  const { isOpen, setter, children } = props;
+  const { isOpen, setter, target, children } = props;
+  const closeModal = () =>
+    setter({
+      type: 'close',
+      payload: {
+        target: target,
+      },
+    });
+
   return (
     <Modal
       isOpen={isOpen}
-      onRequestClose={() => setter(false)}
+      onRequestClose={closeModal}
       shouldFocusAfterRender={false}
       style={{
         overlay: {

--- a/packages/frontend/src/components/Modal/ModalType.ts
+++ b/packages/frontend/src/components/Modal/ModalType.ts
@@ -1,0 +1,15 @@
+export type ActionPayload = {
+  target: string;
+};
+
+export type OpenAction = {
+  type: 'open';
+  payload: ActionPayload;
+};
+
+export type CloseAction = {
+  type: 'close';
+  payload: ActionPayload;
+};
+
+export type ModalReducerAction = OpenAction | CloseAction;

--- a/packages/frontend/src/components/Modal/ModalType.ts
+++ b/packages/frontend/src/components/Modal/ModalType.ts
@@ -13,3 +13,9 @@ export type CloseAction = {
 };
 
 export type ModalReducerAction = OpenAction | CloseAction;
+
+export interface ModalBaseProps {
+  isOpen: boolean;
+  setter: React.Dispatch<ModalReducerAction>;
+  target: string;
+}

--- a/packages/frontend/src/components/Modal/SelectModal.tsx
+++ b/packages/frontend/src/components/Modal/SelectModal.tsx
@@ -4,11 +4,14 @@ import { nanoid } from 'nanoid';
 
 import styled from '@cyfm/styled';
 
+import { ModalReducerAction } from './ModalType';
+
 import Button from './ModalButton';
 
 interface ModalProps {
   isOpen: boolean;
-  setter: (isOpen: boolean) => void;
+  setter: React.Dispatch<ModalReducerAction>;
+  target: string;
   value: string;
   changeValue: (value: string) => void;
   selections: string[];
@@ -40,13 +43,19 @@ const ButtonWrapper = styled.div`
 `;
 
 const SelectModal = (props: ModalProps) => {
-  const { isOpen, setter, value, changeValue, selections } = props;
+  const { isOpen, setter, target, value, changeValue, selections } = props;
 
-  const closeModal = () => setter(false);
+  const closeModal = () =>
+    setter({
+      type: 'close',
+      payload: {
+        target: target,
+      },
+    });
   return (
     <Modal
       isOpen={isOpen}
-      onRequestClose={() => setter(false)}
+      onRequestClose={closeModal}
       shouldFocusAfterRender={false}
       style={{
         overlay: {

--- a/packages/frontend/src/components/Modal/SelectModal.tsx
+++ b/packages/frontend/src/components/Modal/SelectModal.tsx
@@ -4,14 +4,10 @@ import { nanoid } from 'nanoid';
 
 import styled from '@cyfm/styled';
 
-import { ModalReducerAction } from './ModalType';
-
 import Button from './ModalButton';
+import type { ModalBaseProps } from './ModalType';
 
-interface ModalProps {
-  isOpen: boolean;
-  setter: React.Dispatch<ModalReducerAction>;
-  target: string;
+interface ModalProps extends ModalBaseProps {
   value: string;
   changeValue: (value: string) => void;
   selections: string[];

--- a/packages/frontend/src/components/TestCodeEditor.tsx
+++ b/packages/frontend/src/components/TestCodeEditor.tsx
@@ -1,8 +1,10 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useReducer } from 'react';
 import type { MutableRefObject } from 'react';
 import { nanoid } from 'nanoid';
 import Button from 'components/Button';
 import styled from '@cyfm/styled';
+
+import { ModalReducerAction } from 'components/Modal/ModalType';
 
 import TestCodeViewer from './TestCodeViewer';
 import MessageModal from 'components/Modal/MessageModal';
@@ -12,6 +14,10 @@ interface TestCase {
   code: string;
   id: string;
 }
+
+type ModalState = {
+  openMessage: boolean;
+};
 
 const FlexWrapper = styled.div`
   display: flex;
@@ -54,8 +60,31 @@ const TestCodeEditor = ({
   testCases: TestCase[];
   setTestCases: React.Dispatch<React.SetStateAction<TestCase[]>>;
 }) => {
-  const [isMessage, setMessage] = useState(false);
-  const [messages, setMessages] = useState<string>('');
+  const [modalStates, dispatch] = useReducer(
+    (state: ModalState, action: ModalReducerAction): ModalState => {
+      switch (action.type) {
+        case 'open':
+          switch (action.payload.target) {
+            case 'message':
+              return { ...state, openMessage: true };
+            default:
+              return state;
+          }
+        case 'close':
+          switch (action.payload.target) {
+            case 'message':
+              return { ...state, openMessage: false };
+            default:
+              return state;
+          }
+      }
+    },
+    {
+      openMessage: false,
+    },
+  );
+
+  const [messages, setMessages] = useState('');
   const titleRef: MutableRefObject<HTMLInputElement | undefined> = useRef();
   const codeRef: MutableRefObject<HTMLInputElement | undefined> = useRef();
 
@@ -88,7 +117,7 @@ const TestCodeEditor = ({
       titleInput.value = '';
       codeInput.value = '';
     } else {
-      setMessage(true);
+      dispatch({ type: 'open', payload: { target: 'message' } });
     }
   }, [titleRef, codeRef, setTestCases]);
 
@@ -104,8 +133,9 @@ const TestCodeEditor = ({
   return (
     <Wrapper>
       <MessageModal
-        isOpen={isMessage}
-        setter={setMessage}
+        isOpen={modalStates.openMessage}
+        setter={dispatch}
+        target={'message'}
         message={messages}
         close={true}
       />

--- a/packages/frontend/src/components/TestCodeEditor.tsx
+++ b/packages/frontend/src/components/TestCodeEditor.tsx
@@ -62,21 +62,10 @@ const TestCodeEditor = ({
 }) => {
   const [modalStates, dispatch] = useReducer(
     (state: ModalState, action: ModalReducerAction): ModalState => {
-      switch (action.type) {
-        case 'open':
-          switch (action.payload.target) {
-            case 'message':
-              return { ...state, openMessage: true };
-            default:
-              return state;
-          }
-        case 'close':
-          switch (action.payload.target) {
-            case 'message':
-              return { ...state, openMessage: false };
-            default:
-              return state;
-          }
+      if (action.payload.target === 'message') {
+        return { ...state, openMessage: action.type === 'open' };
+      } else {
+        return state;
       }
     },
     {

--- a/packages/frontend/src/pages/DebugPage/index.tsx
+++ b/packages/frontend/src/pages/DebugPage/index.tsx
@@ -37,11 +37,7 @@ import 'ace-builds/src-noconflict/mode-javascript';
 import 'ace-builds/src-noconflict/theme-twilight';
 import '@toast-ui/editor/dist/toastui-editor.css';
 import '@toast-ui/editor/dist/theme/toastui-editor-dark.css';
-import {
-  LOGIN_VALIDATION_FAIL_MESSAGE,
-  SUBMIT_FAIL_MESSAGE,
-  TIMEOUT_MESSAGE,
-} from './message';
+import { LOGIN_VALIDATION_FAIL_MESSAGE } from './message';
 
 const ViewerWrapper = styled.div`
   display: flex;
@@ -79,9 +75,9 @@ const DebugPage: React.FC = () => {
   const { isLogin } = useContext(LoginContext);
   const [output, setOutput] = useState('');
   const [isLoading, setLoading] = useState(false);
-  const [isTimeover, setTimeover] = useState(false);
-  const [isError, setError] = useState(false);
-  const [isLoginCheck, setLoginCheck] = useState(false);
+  const [message, setMessage] = useState('');
+  const [isMessage, setShowMessage] = useState(false);
+
   const history = useHistory();
 
   const unblockRef = useRef(false);
@@ -147,7 +143,8 @@ const DebugPage: React.FC = () => {
 
   const submit = () => {
     if (!isLogin) {
-      setLoginCheck(true);
+      setMessage(LOGIN_VALIDATION_FAIL_MESSAGE);
+      setShowMessage(true);
       return;
     }
 
@@ -272,21 +269,9 @@ const DebugPage: React.FC = () => {
           </ButtonFooter>
           <LoadingModal isOpen={isLoading} />
           <MessageModal
-            isOpen={isTimeover}
-            setter={setTimeover}
-            message={TIMEOUT_MESSAGE}
-            close={true}
-          />
-          <MessageModal
-            isOpen={isError}
-            setter={setError}
-            message={SUBMIT_FAIL_MESSAGE}
-            close={true}
-          />
-          <MessageModal
-            isOpen={isLoginCheck}
-            setter={setLoginCheck}
-            message={LOGIN_VALIDATION_FAIL_MESSAGE}
+            isOpen={isMessage}
+            setter={setShowMessage}
+            message={message}
             close={true}
           />
         </>

--- a/packages/frontend/src/pages/DebugPage/index.tsx
+++ b/packages/frontend/src/pages/DebugPage/index.tsx
@@ -31,7 +31,7 @@ import LoadingModal from 'components/Modal/LoadingModal';
 
 import { useSandbox } from 'hooks/useSandbox';
 import { useBlockUnload } from 'hooks/useBlockUnload';
-import { debugReducer } from './reducer';
+import { debugReducer, modalReducer } from './reducer';
 
 import 'ace-builds/src-noconflict/mode-javascript';
 import 'ace-builds/src-noconflict/theme-twilight';
@@ -72,11 +72,14 @@ const DebugPage: React.FC = () => {
     code: '',
     testCode: [],
   });
+  const [modalStates, modalDispatch] = useReducer(modalReducer, {
+    openLoading: false,
+    openMessage: false,
+  });
+
   const { isLogin } = useContext(LoginContext);
   const [output, setOutput] = useState('');
-  const [isLoading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
-  const [isMessage, setShowMessage] = useState(false);
 
   const history = useHistory();
 
@@ -144,7 +147,10 @@ const DebugPage: React.FC = () => {
   const submit = () => {
     if (!isLogin) {
       setMessage(LOGIN_VALIDATION_FAIL_MESSAGE);
-      setShowMessage(true);
+      modalDispatch({
+        type: 'open',
+        payload: { target: 'message' },
+      });
       return;
     }
 
@@ -175,7 +181,7 @@ const DebugPage: React.FC = () => {
     const startTime = Date.now();
 
     const loadTimer = setTimeout(() => {
-      setLoading(true);
+      modalDispatch({ type: 'open', payload: { target: 'loading' } });
     }, 500);
 
     const timeout = 5 * 1000;
@@ -195,7 +201,7 @@ const DebugPage: React.FC = () => {
       (event: CustomEventInit) => {
         clearTimeout(killTimer);
         clearTimeout(loadTimer);
-        setLoading(false);
+        modalDispatch({ type: 'close', payload: { target: 'loading' } });
 
         const endTime = Date.now();
         setOutput(prev =>
@@ -267,10 +273,11 @@ const DebugPage: React.FC = () => {
             <Button onClick={onExecute}>실행</Button>
             <Button onClick={onSubmit}>제출</Button>
           </ButtonFooter>
-          <LoadingModal isOpen={isLoading} />
+          <LoadingModal isOpen={modalStates.openLoading} />
           <MessageModal
-            isOpen={isMessage}
-            setter={setShowMessage}
+            isOpen={modalStates.openMessage}
+            setter={modalDispatch}
+            target={'message'}
             message={message}
             close={true}
           />

--- a/packages/frontend/src/pages/DebugPage/message.ts
+++ b/packages/frontend/src/pages/DebugPage/message.ts
@@ -1,7 +1,2 @@
-export const TIMEOUT_MESSAGE = '실행 시간이 5초를 초과했습니다.';
-
-export const SUBMIT_FAIL_MESSAGE =
-  '제출에 실패했습니다.\n담당자에게 문의 바랍니다.';
-
 export const LOGIN_VALIDATION_FAIL_MESSAGE =
   '문제 풀이 제출을 위해서는\n로그인이 필요합니다.';

--- a/packages/frontend/src/pages/DebugPage/reducer.ts
+++ b/packages/frontend/src/pages/DebugPage/reducer.ts
@@ -1,3 +1,5 @@
+import { ModalReducerAction } from 'components/Modal/ModalType';
+
 type DebugStates = {
   content: string;
   testCode: string[];
@@ -37,4 +39,35 @@ const debugReducer = (
   }
 };
 
-export { debugReducer };
+type ModalState = {
+  openLoading: boolean;
+  openMessage: boolean;
+};
+
+const modalReducer = (
+  state: ModalState,
+  action: ModalReducerAction,
+): ModalState => {
+  switch (action.type) {
+    case 'open':
+      switch (action.payload.target) {
+        case 'loading':
+          return { ...state, openLoading: true };
+        case 'message':
+          return { ...state, openMessage: true };
+        default:
+          return state;
+      }
+    case 'close':
+      switch (action.payload.target) {
+        case 'loading':
+          return { ...state, openLoading: false };
+        case 'message':
+          return { ...state, openMessage: false };
+        default:
+          return state;
+      }
+  }
+};
+
+export { debugReducer, modalReducer };

--- a/packages/frontend/src/pages/DebugPage/reducer.ts
+++ b/packages/frontend/src/pages/DebugPage/reducer.ts
@@ -48,25 +48,14 @@ const modalReducer = (
   state: ModalState,
   action: ModalReducerAction,
 ): ModalState => {
-  switch (action.type) {
-    case 'open':
-      switch (action.payload.target) {
-        case 'loading':
-          return { ...state, openLoading: true };
-        case 'message':
-          return { ...state, openMessage: true };
-        default:
-          return state;
-      }
-    case 'close':
-      switch (action.payload.target) {
-        case 'loading':
-          return { ...state, openLoading: false };
-        case 'message':
-          return { ...state, openMessage: false };
-        default:
-          return state;
-      }
+  const isOpen = action.type === 'open';
+  switch (action.payload.target) {
+    case 'loading':
+      return { ...state, openLoading: isOpen };
+    case 'message':
+      return { ...state, openMessage: isOpen };
+    default:
+      return state;
   }
 };
 

--- a/packages/frontend/src/pages/WritePage/constant.ts
+++ b/packages/frontend/src/pages/WritePage/constant.ts
@@ -1,3 +1,5 @@
 export const LANGUAGE_SELECTIONS = ['C++', 'Java', 'JavaScript', 'Python'];
 
 export const VALID_LANGUAGES = ['JavaScript'];
+
+export const LEVEL_SELECTIONS = ['1', '2', '3'];

--- a/packages/frontend/src/pages/WritePage/index.tsx
+++ b/packages/frontend/src/pages/WritePage/index.tsx
@@ -160,10 +160,8 @@ const WritePage = () => {
   const [isLoading, setLoading] = useState(false);
   const [isSubmit, setSubmit] = useState(false);
   const [isSuccess, setSuccess] = useState(false);
-  const [isError, setError] = useState(false);
-  const [isValid, setValid] = useState(false);
-  const [isValidLang, setValidLang] = useState(false);
-  const [validationMessages, setValidationMessages] = useState<string>('');
+  const [message, setMessage] = useState('');
+  const [isShowMessage, setShowMessage] = useState(false);
 
   const unblockRef = useRef(false);
   useBlockUnload(code, unblockRef);
@@ -259,7 +257,7 @@ const WritePage = () => {
   const inputValidation = useCallback(() => {
     const titleContext = titleInputRef.current?.value;
     if ((titleContext as string).length === 0) {
-      setValidationMessages(VALIDATION_FAIL_MESSAGE['title']);
+      setMessage(VALIDATION_FAIL_MESSAGE['title']);
       return false;
     }
 
@@ -267,19 +265,19 @@ const WritePage = () => {
       .getInstance()
       .getMarkdown();
     if ((markdownContext as string).length === 0) {
-      setValidationMessages(VALIDATION_FAIL_MESSAGE['markdown']);
+      setMessage(VALIDATION_FAIL_MESSAGE['markdown']);
       return false;
     }
 
     const codeContext = code;
     if ((codeContext as string).length === 0) {
-      setValidationMessages(VALIDATION_FAIL_MESSAGE['code']);
+      setMessage(VALIDATION_FAIL_MESSAGE['code']);
       return false;
     }
 
     const testcaseContext = testCases;
     if (testcaseContext.length === 0) {
-      setValidationMessages(VALIDATION_FAIL_MESSAGE['testcase']);
+      setMessage(VALIDATION_FAIL_MESSAGE['testcase']);
       return false;
     }
 
@@ -290,19 +288,16 @@ const WritePage = () => {
     if (VALID_LANGUAGES.includes(category)) {
       return true;
     } else {
+      setMessage(CHECK_IS_VALID_LANGUAGE);
       return false;
     }
   }, [category]);
 
   const submitValidation = () => {
-    if (isValidLanguage()) {
-      if (inputValidation()) {
-        setSubmit(true);
-      } else {
-        setValid(true);
-      }
+    if (isValidLanguage() && inputValidation()) {
+      setSubmit(true);
     } else {
-      setValidLang(true);
+      setShowMessage(true);
     }
   };
 
@@ -334,10 +329,12 @@ const WritePage = () => {
           history.push('/');
         }, 2000);
       } else {
-        setError(true);
+        setMessage(SUBMIT_FAIL_MESSAGE);
+        setShowMessage(true);
       }
     } catch (err) {
-      setError(true);
+      setMessage(SUBMIT_FAIL_MESSAGE);
+      setShowMessage(true);
     }
   };
 
@@ -454,15 +451,9 @@ const WritePage = () => {
                 }}
               />
               <MessageModal
-                isOpen={isValid}
-                setter={setValid}
-                message={validationMessages}
-                close={true}
-              />
-              <MessageModal
-                isOpen={isValidLang}
-                setter={setValidLang}
-                message={CHECK_IS_VALID_LANGUAGE}
+                isOpen={isShowMessage}
+                setter={setShowMessage}
+                message={message}
                 close={true}
               />
               <MessageModal
@@ -470,12 +461,6 @@ const WritePage = () => {
                 setter={setSuccess}
                 message={SUBMIT_SUCCESS_MESSAGE}
                 close={false}
-              />
-              <MessageModal
-                isOpen={isError}
-                setter={setError}
-                message={SUBMIT_FAIL_MESSAGE}
-                close={true}
               />
             </>
           }

--- a/packages/frontend/src/pages/WritePage/reducer.ts
+++ b/packages/frontend/src/pages/WritePage/reducer.ts
@@ -1,0 +1,69 @@
+type ModalState = {
+  openCategory: boolean;
+  openLevel: boolean;
+  openLoading: boolean;
+  openSubmit: boolean;
+  openSuccess: boolean;
+  openMessage: boolean;
+};
+
+type ActionPayload = {
+  target: string;
+};
+
+type OpenAction = {
+  type: 'open';
+  payload: ActionPayload;
+};
+
+type CloseAction = {
+  type: 'close';
+  payload: ActionPayload;
+};
+
+type ModalReducerAction = OpenAction | CloseAction;
+
+const modalReducer = (
+  state: ModalState,
+  action: ModalReducerAction,
+): ModalState => {
+  switch (action.type) {
+    case 'open':
+      switch (action.payload.target) {
+        case 'category':
+          return { ...state, openCategory: true };
+        case 'level':
+          return { ...state, openLevel: true };
+        case 'loading':
+          return { ...state, openLoading: true };
+        case 'submit':
+          return { ...state, openSubmit: true };
+        case 'success':
+          return { ...state, openSuccess: true };
+        case 'message':
+          return { ...state, openMessage: true };
+        default:
+          return state;
+      }
+
+    case 'close':
+      switch (action.payload.target) {
+        case 'category':
+          return { ...state, openCategory: false };
+        case 'level':
+          return { ...state, openLevel: false };
+        case 'loading':
+          return { ...state, openLoading: false };
+        case 'submit':
+          return { ...state, openSubmit: false };
+        case 'success':
+          return { ...state, openSuccess: false };
+        case 'message':
+          return { ...state, openMessage: false };
+        default:
+          return state;
+      }
+  }
+};
+
+export { modalReducer };

--- a/packages/frontend/src/pages/WritePage/reducer.ts
+++ b/packages/frontend/src/pages/WritePage/reducer.ts
@@ -27,42 +27,22 @@ const modalReducer = (
   state: ModalState,
   action: ModalReducerAction,
 ): ModalState => {
-  switch (action.type) {
-    case 'open':
-      switch (action.payload.target) {
-        case 'category':
-          return { ...state, openCategory: true };
-        case 'level':
-          return { ...state, openLevel: true };
-        case 'loading':
-          return { ...state, openLoading: true };
-        case 'submit':
-          return { ...state, openSubmit: true };
-        case 'success':
-          return { ...state, openSuccess: true };
-        case 'message':
-          return { ...state, openMessage: true };
-        default:
-          return state;
-      }
-
-    case 'close':
-      switch (action.payload.target) {
-        case 'category':
-          return { ...state, openCategory: false };
-        case 'level':
-          return { ...state, openLevel: false };
-        case 'loading':
-          return { ...state, openLoading: false };
-        case 'submit':
-          return { ...state, openSubmit: false };
-        case 'success':
-          return { ...state, openSuccess: false };
-        case 'message':
-          return { ...state, openMessage: false };
-        default:
-          return state;
-      }
+  const isOpen = action.type === 'open';
+  switch (action.payload.target) {
+    case 'category':
+      return { ...state, openCategory: isOpen };
+    case 'level':
+      return { ...state, openLevel: isOpen };
+    case 'loading':
+      return { ...state, openLoading: isOpen };
+    case 'submit':
+      return { ...state, openSubmit: isOpen };
+    case 'success':
+      return { ...state, openSuccess: isOpen };
+    case 'message':
+      return { ...state, openMessage: isOpen };
+    default:
+      return state;
   }
 };
 


### PR DESCRIPTION
**작업 목록**
- 케이스별로 생성되어있던 Message Modal을 통합
- Modal의 `setter`를 `React.dispatch`로 변경
- 각 페이지에서 Modal 상태 관리를 Reducer로 수정