### PR TITLE
refactor: 공통 타입 분리 및 인터페이스 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,9 @@
       "files": ["**/*.ts", "**/*.tsx"],
       "rules": {
         "no-use-before-define": "off",
-        "@typescript-eslint/no-use-before-define": ["error"]
+        "@typescript-eslint/no-use-before-define": ["error"],
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": ["error"]
       },
       "parser": "@typescript-eslint/parser",
       "extends": ["plugin:@typescript-eslint/recommended"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,11 @@ COPY packages/debounce/package.json packages/debounce/package.json
 COPY packages/styled/package.json packages/styled/package.json
 COPY packages/backend/package.json packages/backend/package.json
 COPY packages/frontend/package.json packages/frontend/package.json
+COPY packages/types/package.json packages/types/package.json
 
 
 RUN yarn --silent --frozen-lockfile --ignore-scripts
+RUN yarn bootstrap
 
 COPY packages/backend/ packages/backend/
 COPY tsconfig.json ./
@@ -33,7 +35,7 @@ ENV REACT_APP_API_URL=$API_URL
 ENV REACT_APP_CLIENT_ID=$CLIENT_ID
 
 COPY packages/ packages/
-RUN yarn bootstrap && yarn build:frontend
+RUN yarn build:frontend
 
 RUN yarn --prod --silent --frozen-lockfile --ignore-scripts
 RUN yarn --silent cache clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ COPY packages/types/package.json packages/types/package.json
 
 
 RUN yarn --silent --frozen-lockfile --ignore-scripts
+
+COPY packages/types/ packages/types/
 RUN yarn bootstrap
 
 COPY packages/backend/ packages/backend/

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -23,6 +23,7 @@
     "vm2": "^3.9.5"
   },
   "devDependencies": {
+    "@cyfm/types": "^0.0.0",
     "@types/express": "^4.17.13",
     "@types/express-mysql-session": "^2.1.3",
     "@types/express-session": "^1.17.4",

--- a/packages/backend/src/model/Problem.ts
+++ b/packages/backend/src/model/Problem.ts
@@ -7,11 +7,12 @@ import {
   Entity,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import type { IProblem } from '@cyfm/types';
 
 import { User } from './User';
 
 @Entity()
-export class Problem extends BaseEntity {
+export class Problem extends BaseEntity implements IProblem {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/packages/backend/src/model/ProblemCode.ts
+++ b/packages/backend/src/model/ProblemCode.ts
@@ -1,8 +1,9 @@
 import mongoose from 'mongoose';
+import type { IProblemCode } from '@cyfm/types';
 
 const { Schema } = mongoose;
 
-export const ProblemCode = new Schema({
+export const ProblemCode = new Schema<IProblemCode>({
   code: String,
   testCode: [String],
   content: String,

--- a/packages/backend/src/model/SubmitCode.ts
+++ b/packages/backend/src/model/SubmitCode.ts
@@ -1,8 +1,9 @@
 import mongoose from 'mongoose';
+import type { ISubmitCode } from '@cyfm/types';
 
 const { Schema } = mongoose;
 
-export const SubmitCode = new Schema({
+export const SubmitCode = new Schema<ISubmitCode>({
   code: String,
   testResult: [String],
 });

--- a/packages/backend/src/model/SubmitLog.ts
+++ b/packages/backend/src/model/SubmitLog.ts
@@ -7,12 +7,13 @@ import {
   Entity,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import type { ISubmitLog } from '@cyfm/types';
 
 import { User } from './User';
 import { Problem } from './Problem';
 
 @Entity()
-export class SubmitLog extends BaseEntity {
+export class SubmitLog extends BaseEntity implements ISubmitLog {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/packages/backend/src/model/User.ts
+++ b/packages/backend/src/model/User.ts
@@ -1,7 +1,8 @@
 import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import type { IUser } from '@cyfm/types';
 
 @Entity()
-export class User extends BaseEntity {
+export class User extends BaseEntity implements IUser {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/packages/backend/src/service/statisticService.ts
+++ b/packages/backend/src/service/statisticService.ts
@@ -1,7 +1,4 @@
 /* eslint-disable no-nested-ternary */
-/* eslint-disable prettier/prettier */
-/* eslint-disable prefer-destructuring */
-/* eslint-disable dot-notation */
 import express from 'express';
 import { getRepository } from 'typeorm';
 import { Problem } from '../model/Problem';

--- a/packages/backend/src/service/submitService.ts
+++ b/packages/backend/src/service/submitService.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-disable no-plusplus */
-/* eslint-disable dot-notation */
 import { SubmitCodeModel } from '../settings/mongoConfig';
 import { SubmitLog } from '../model/SubmitLog';
 import { Problem } from '../model/Problem';
@@ -14,6 +13,7 @@ const saveSubmitCode = async ({ code, testResult }) => {
   return codeData;
 };
 
+/* eslint-disable-next-line dot-notation */
 const getCodeId = codeData => codeData['_id'].toString();
 
 const saveSubmitLog = async ({ problem, user, codeId, testResult }) => {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -42,6 +42,7 @@
     "web-vitals": "^1.0.1"
   },
   "devDependencies": {
+    "@cyfm/types": "^0.0.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/packages/frontend/src/components/Modal/GuideModal.tsx
+++ b/packages/frontend/src/components/Modal/GuideModal.tsx
@@ -6,7 +6,7 @@ import styled from '@cyfm/styled';
 
 import Button from './ModalButton';
 
-import TESTCASES from './GuidelineCase';
+import GUIDELINES from './GuidelineCase';
 
 interface ModalProps {
   isOpen: boolean;
@@ -126,11 +126,11 @@ const GuideModal = (props: ModalProps) => {
           </PageButton>
         </TitleWrapper>
         <ContentWrapper>
-          {TESTCASES.map(testcase => (
+          {GUIDELINES.map(guideline => (
             <TestCaseWrapper key={nanoid()}>
-              <TestCaseTitle>{testcase.title}</TestCaseTitle>
-              <TestCaseContent>{testcase.content}</TestCaseContent>
-              {testcase.codes.map(code => (
+              <TestCaseTitle>{guideline.title}</TestCaseTitle>
+              <TestCaseContent>{guideline.content}</TestCaseContent>
+              {guideline.codes.map(code => (
                 <TestCaseCode>{code}</TestCaseCode>
               ))}
             </TestCaseWrapper>

--- a/packages/frontend/src/components/Modal/GuidelineCase.ts
+++ b/packages/frontend/src/components/Modal/GuidelineCase.ts
@@ -1,10 +1,6 @@
-interface TestCase {
-  title: string;
-  content: string;
-  codes: string[];
-}
+import type { IGuideline } from '@cyfm/types';
 
-const TESTCASES: TestCase[] = [
+const GUIDELINES: IGuideline[] = [
   {
     title: `expect(val1).to.equal(val2);`,
     content: `'val1'과 'val2'가 동일한지 확인할 때 사용합니다.`,
@@ -39,4 +35,4 @@ const TESTCASES: TestCase[] = [
   },
 ];
 
-export default TESTCASES;
+export default GUIDELINES;

--- a/packages/frontend/src/components/ResultViewer.tsx
+++ b/packages/frontend/src/components/ResultViewer.tsx
@@ -1,19 +1,9 @@
 import styled from '@cyfm/styled';
-
-enum ResultCode {
-  'success',
-  'fail',
-  'timeout',
-  'pending',
-}
-
-interface TestCase {
-  id: string;
-  result: ResultCode;
-}
+import { ResultCode } from '@cyfm/types';
+import type { ITestCaseResult } from '@cyfm/types';
 
 interface ResultProps {
-  TestCases: TestCase[];
+  TestCases: ITestCaseResult[];
 }
 
 const ResultViewerWrapper = styled.div`

--- a/packages/frontend/src/pages/DebugPage/reducer.ts
+++ b/packages/frontend/src/pages/DebugPage/reducer.ts
@@ -1,8 +1,7 @@
-type DebugStates = {
-  content: string;
-  testCode: string[];
+import type { IProblemCode } from '@cyfm/types';
+
+type DebugStates = IProblemCode & {
   initCode: string;
-  code: string;
 };
 
 type InitAction = {

--- a/packages/frontend/src/pages/GuidePage/GuidelineCase.ts
+++ b/packages/frontend/src/pages/GuidePage/GuidelineCase.ts
@@ -1,10 +1,6 @@
-interface TestCase {
-  title: string;
-  content: string;
-  codes: string[];
-}
+import type { IGuideline } from '@cyfm/types';
 
-const TESTCASES: TestCase[] = [
+const GUIDELINES: IGuideline[] = [
   {
     title: `expect(val1).to.equal(val2);`,
     content: `'val1'과 'val2'가 동일한지 확인할 때 사용합니다.`,
@@ -39,4 +35,4 @@ const TESTCASES: TestCase[] = [
   },
 ];
 
-export default TESTCASES;
+export default GUIDELINES;

--- a/packages/frontend/src/pages/GuidePage/index.tsx
+++ b/packages/frontend/src/pages/GuidePage/index.tsx
@@ -2,7 +2,7 @@ import { nanoid } from 'nanoid';
 
 import styled from '@cyfm/styled';
 
-import TESTCASES from './GuidelineCase';
+import GUIDELINES from './GuidelineCase';
 
 const GuideWrapper = styled.div`
   display: flex;
@@ -66,11 +66,11 @@ const GuidePage = () => {
     <GuideWrapper>
       <TitleWrapper>테스트케이스 가이드라인</TitleWrapper>
       <ContentWrapper>
-        {TESTCASES.map(testcase => (
+        {GUIDELINES.map(guideline => (
           <TestCaseWrapper key={nanoid()}>
-            <TestCaseTitle>{testcase.title}</TestCaseTitle>
-            <TestCaseContent>{testcase.content}</TestCaseContent>
-            {testcase.codes.map(code => (
+            <TestCaseTitle>{guideline.title}</TestCaseTitle>
+            <TestCaseContent>{guideline.content}</TestCaseContent>
+            {guideline.codes.map(code => (
               <TestCaseCode>{code}</TestCaseCode>
             ))}
           </TestCaseWrapper>

--- a/packages/frontend/src/pages/IntroPage/index.tsx
+++ b/packages/frontend/src/pages/IntroPage/index.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { nanoid } from 'nanoid';
 
 import styled from '@cyfm/styled';
+import type { IProblem } from '@cyfm/types';
 
 import logo from 'assets/images/logo.svg';
 

--- a/packages/frontend/src/pages/IntroPage/index.tsx
+++ b/packages/frontend/src/pages/IntroPage/index.tsx
@@ -117,23 +117,17 @@ const DebugLink = styled(Link)`
   font-weight: bold;
 `;
 
-interface Problem {
-  problem_id: number;
-  problem_title: string;
-  problem_category: string;
-  problem_level: number;
-  problem_codeId: string;
-  problem_authorId: number;
-  count: string;
-}
+type ProblemStatistics = {
+  [k in keyof IProblem as `problem_${k}`]: IProblem[k];
+};
 
 interface Statistics {
   problemCount: number;
   submitCount: number;
   userCount: number;
-  mostSubmitProblems: Problem[];
-  mostCorrectProblems: Problem[];
-  mostWrongProblems: Problem[];
+  mostSubmitProblems: ProblemStatistics[];
+  mostCorrectProblems: ProblemStatistics[];
+  mostWrongProblems: ProblemStatistics[];
 }
 
 const convertNum = (num: string) => {
@@ -152,9 +146,15 @@ const IntroPage = () => {
   const [problemCount, setProblemCount] = useState('0');
   const [submitCount, setSubmitCount] = useState('0');
   const [userCount, setUserCount] = useState('0');
-  const [mostSubmitProblems, setSubmitProblems] = useState<Problem[]>([]);
-  const [mostCorrectProblems, setCorrectProblems] = useState<Problem[]>([]);
-  const [mostWrongProblems, setWrongProblems] = useState<Problem[]>([]);
+  const [mostSubmitProblems, setSubmitProblems] = useState<ProblemStatistics[]>(
+    [],
+  );
+  const [mostCorrectProblems, setCorrectProblems] = useState<
+    ProblemStatistics[]
+  >([]);
+  const [mostWrongProblems, setWrongProblems] = useState<ProblemStatistics[]>(
+    [],
+  );
 
   const incEvent = useCallback(
     (

--- a/packages/frontend/src/pages/ListPage/index.tsx
+++ b/packages/frontend/src/pages/ListPage/index.tsx
@@ -11,6 +11,8 @@ import styled from '@cyfm/styled';
 import { paginationReducer } from './reducer';
 import LoadingModal from 'components/Modal/LoadingModal';
 
+import type { IProblem } from '@cyfm/types';
+
 const Background = styled.div`
   width: 100%;
 `;
@@ -44,23 +46,7 @@ const Sign = styled.div`
   font-size: 1.5em;
 `;
 
-interface User {
-  id: number;
-  name: string;
-  oauthType: string;
-  token: string;
-}
-
-interface Item {
-  id: number;
-  title: string;
-  author: User;
-  category: string;
-  codeId: string;
-  level: number;
-}
-
-let result: Item[] | null;
+let result: IProblem[] | null;
 let timeout: number;
 
 const ListPage: React.FC = () => {
@@ -134,7 +120,7 @@ const ListPage: React.FC = () => {
   return (
     <Background>
       <ListWrapper ref={itemsList}>
-        {paginationState.items.map((item: Item) => (
+        {paginationState.items.map(item => (
           <SignLink to={`/debug/${item.codeId}`} key={item.codeId}>
             <Sign>{item.title}</Sign>
           </SignLink>

--- a/packages/frontend/src/pages/ListPage/reducer.ts
+++ b/packages/frontend/src/pages/ListPage/reducer.ts
@@ -1,39 +1,25 @@
-interface User {
-  id: number;
-  name: string;
-  oauthType: string;
-  token: string;
-}
+import type { IProblem } from '@cyfm/types';
 
-interface Item {
-  id: number;
-  title: string;
-  author: User;
-  category: string;
-  codeId: string;
-  level: number;
-}
-
-interface paginationState {
-  items: Item[];
+interface IPaginationState {
+  items: IProblem[];
   offset: number;
 }
 
-interface paginationAction {
+interface IPaginationAction {
   type: string;
-  items?: Item[];
+  items?: IProblem[];
   offset: number;
 }
 
 const paginationReducer = (
-  state: paginationState,
-  action: paginationAction,
-): paginationState => {
+  state: IPaginationState,
+  action: IPaginationAction,
+): IPaginationState => {
   switch (action.type) {
     case 'addItems':
       return {
         ...state,
-        items: [...state.items, ...(action.items as Item[])],
+        items: [...state.items, ...(action.items as IProblem[])],
       };
     case 'incOffset':
       return {

--- a/packages/frontend/src/pages/ResultPage/index.tsx
+++ b/packages/frontend/src/pages/ResultPage/index.tsx
@@ -1,19 +1,15 @@
 import React, { useState, useEffect, useCallback, useContext } from 'react';
 import { Redirect, useHistory } from 'react-router';
 import { nanoid } from 'nanoid';
-import { ResultCode } from './enums';
+import { ResultCode } from '@cyfm/types';
+import type { ITestCase } from '@cyfm/types';
 
 import SocketContext from 'contexts/SocketContext';
 import ResultViewer from 'components/ResultViewer';
 
-interface TestCase {
-  id: string;
-  result: ResultCode;
-}
-
 interface State {
   code?: string;
-  testCode?: TestCase[];
+  testCode?: ITestCase[];
   problemId?: string;
 }
 
@@ -29,7 +25,7 @@ const ResultPage = () => {
       .fill(0)
       .map(val => nanoid()),
   );
-  const [result, setResult] = useState<TestCase[]>(
+  const [result, setResult] = useState(
     idList.map(value => {
       return { id: value, result: ResultCode.pending };
     }),

--- a/packages/frontend/src/pages/WritePage/index.tsx
+++ b/packages/frontend/src/pages/WritePage/index.tsx
@@ -47,20 +47,17 @@ import ConfirmModal from 'components/Modal/ConfirmModal';
 import LoadingModal from 'components/Modal/LoadingModal';
 import SelectModal from 'components/Modal/SelectModal';
 
-interface TestCase {
-  title: string;
-  code: string;
-  id: string;
-}
+import type { ITestCase, Category } from '@cyfm/types';
 
-const CATEGORY = {
+type Language = keyof typeof Category;
+const CATEGORY: Record<Language, string> = {
   'C++': 'c_cpp',
   Java: 'java',
   JavaScript: 'javascript',
   Python: 'python',
 };
 
-const TABSIZE = {
+const TABSIZE: Record<Language, number> = {
   'C++': 2,
   Java: 2,
   JavaScript: 2,
@@ -153,7 +150,7 @@ const WritePage = () => {
   const { isLogin } = useContext(LoginContext);
   const [code, setCode] = useState('');
   const [output, setOutput] = useState('');
-  const [category, setCategory] = useState('JavaScript');
+  const [category, setCategory] = useState<Language>('JavaScript');
   const [level, setLevel] = useState('1');
   const [isOpenCategory, setOpenCategory] = useState(false);
   const [isOpenLevel, setOpenLevel] = useState(false);
@@ -188,9 +185,9 @@ const WritePage = () => {
     useRef();
 
   const [testCases, setTestCases]: [
-    TestCase[],
-    React.Dispatch<React.SetStateAction<TestCase[]>>,
-  ] = useState<TestCase[]>([]);
+    ITestCase[],
+    React.Dispatch<React.SetStateAction<ITestCase[]>>,
+  ] = useState<ITestCase[]>([]);
 
   const onChange = useCallback(setCode, [setCode]);
 
@@ -379,7 +376,7 @@ const WritePage = () => {
                     isOpen={isOpenCategory}
                     setter={setOpenCategory}
                     value={category}
-                    changeValue={setCategory}
+                    changeValue={setCategory as (value: string) => void}
                     selections={LANGUAGE_SELECTIONS}
                     close={true}
                   />

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@cyfm/types",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^4.5.2"
+  }
+}

--- a/packages/types/src/entities.ts
+++ b/packages/types/src/entities.ts
@@ -1,3 +1,5 @@
+import { ResultCode } from './enums';
+
 export interface IUser {
   name: string;
 }
@@ -29,3 +31,13 @@ export interface ISubmitLog {
   user: IUser;
   problem: IProblem;
 }
+
+export interface ITestCase {
+  title: string;
+  code: string;
+  id: string;
+}
+
+export type ITestCaseResult = Pick<ITestCase, 'id'> & {
+  result: ResultCode;
+};

--- a/packages/types/src/entities.ts
+++ b/packages/types/src/entities.ts
@@ -41,3 +41,9 @@ export interface ITestCase {
 export type ITestCaseResult = Pick<ITestCase, 'id'> & {
   result: ResultCode;
 };
+
+export interface IGuideline {
+  title: string;
+  content: string;
+  codes: string[];
+}

--- a/packages/types/src/entities.ts
+++ b/packages/types/src/entities.ts
@@ -1,0 +1,31 @@
+export interface IUser {
+  name: string;
+}
+
+export interface IProblem {
+  title: string;
+  category: string;
+  level: number;
+  codeId: string;
+  author: IUser;
+}
+
+export interface IProblemCode {
+  code: string;
+  testCode: string[];
+  content: string;
+}
+
+export interface ISubmitCode {
+  code: string;
+  testResult: string[];
+}
+
+export interface ISubmitLog {
+  status: string;
+  correctTestCount: number;
+  wrongTestCount: number;
+  codeId: string;
+  user: IUser;
+  problem: IProblem;
+}

--- a/packages/types/src/enums.ts
+++ b/packages/types/src/enums.ts
@@ -1,3 +1,10 @@
+export enum Category {
+  'C++',
+  'Java',
+  'JavaScript',
+  'Python',
+}
+
 export enum ResultCode {
   'success',
   'fail',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,1 @@
+export * from './entities';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,2 @@
 export * from './entities';
+export * from './enums';

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15334,6 +15334,11 @@ typescript@^4.1.2, typescript@^4.4.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
+typescript@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
+
 uglify-js@^3.1.4:
   version "3.14.2"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.14.2.tgz#d7dd6a46ca57214f54a2d0a43cad0f35db82ac99"


### PR DESCRIPTION
## 변경 사항
- 백엔드와 프론트엔드, 양쪽에서 공통으로 사용되는 인터페이스를 추가
- 파일 내의 중복된 인터페이스, 타입을 패키지로 정리
- 명확하지 않은 이름을 변경