### PR TITLE
chore: 타입 빌드명령 추가 및 esbuild 적용을 통한 빌드 최적화

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
 FROM node:14.17.3-alpine AS node-base
 
-RUN apk update && apk add gettext
-RUN wget -q -O- https://gobinaries.com/tj/node-prune | sh
-
-RUN yarn config set network-timeout 300000
-
-FROM node-base AS nginx-server
-RUN apk add nginx && rm -rf /var/cache/apk/*
-
+RUN apk update && apk add gettext nginx && rm -rf /var/cache/apk/* && \
+    wget -q -O- https://gobinaries.com/tj/node-prune | sh
 
 FROM node-base AS builder
 WORKDIR /app
@@ -19,52 +13,62 @@ COPY packages/types/package.json packages/types/package.json
 COPY packages/backend/package.json packages/backend/package.json
 COPY packages/frontend/package.json packages/frontend/package.json
 
-RUN yarn --silent --frozen-lockfile --ignore-scripts install
-RUN yarn --silent --frozen-lockfile --ignore-scripts bootstrap
+RUN yarn --silent --frozen-lockfile --ignore-scripts install --network-timeout 300000
 
 COPY packages/types/ packages/types/
 COPY tsconfig.json ./
-RUN yarn build:types
+RUN yarn build:types && \
+    yarn --silent --frozen-lockfile --ignore-scripts bootstrap
+
+
+FROM builder AS backend-builder
+WORKDIR /app
 
 COPY packages/backend/ packages/backend/
 RUN yarn build:backend
+
+RUN yarn --prod --silent && \
+    yarn --silent cache clean && \
+    node-prune
+
+FROM builder AS frontend-builder
+WORKDIR /app
+
+COPY packages/ packages/
 
 ARG API_URL
 ARG CLIENT_ID
 ENV REACT_APP_API_URL=$API_URL
 ENV REACT_APP_CLIENT_ID=$CLIENT_ID
 
-COPY packages/ packages/
+ENV GENERATE_SOURCEMAP=false
 RUN yarn build:frontend
 
-RUN yarn --prod --silent --frozen-lockfile --ignore-scripts
-RUN yarn --silent cache clean
-RUN node-prune
 
-
-FROM nginx-server AS production
+FROM node-base AS production
 
 ARG PM2_PUBLIC_KEY
 ARG PM2_SECRET_KEY
 ENV PM2_PUBLIC_KEY=$PM2_PUBLIC_KEY
 ENV PM2_SECRET_KEY=$PM2_SECRET_KEY
 
-RUN yarn --silent global add pm2
-
 WORKDIR /app
 
-COPY --from=builder /app/packages/backend/dist ./dist
-COPY --from=builder /app/packages/backend/package.json ./package.json
-COPY --from=builder /app/packages/frontend/build /var/www/html
-COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/types/dist/ ./packages/types/dist/
+COPY --from=backend-builder /app/packages/backend/dist/ ./packages/backend/dist/
+COPY --from=frontend-builder /app/packages/frontend/build /var/www/html
+COPY --from=backend-builder /app/node_modules ./node_modules
+COPY --from=backend-builder /app/packages/backend/package.json ./packages/backend/package.json
+COPY --from=builder /app/package.json ./package.json
 
 ARG API_HOST
 ARG API_PORT
 ENV API_HOST=$API_HOST
 ENV API_PORT=${API_PORT:-3001}
 
-COPY nginx.conf.template /app/nginx.conf.template
-RUN envsubst '${API_HOST} ${API_PORT}' < ./nginx.conf.template > /etc/nginx/nginx.conf
+COPY nginx.conf.template ./nginx.conf.template
+RUN yarn --silent global add pm2 && \
+    envsubst '${API_HOST} ${API_PORT}' < ./nginx.conf.template > /etc/nginx/nginx.conf
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,19 +16,18 @@ WORKDIR /app
 COPY ["package.json", "yarn.lock", "lerna.json", "./"]
 COPY packages/debounce/package.json packages/debounce/package.json
 COPY packages/styled/package.json packages/styled/package.json
+COPY packages/types/package.json packages/types/package.json
 COPY packages/backend/package.json packages/backend/package.json
 COPY packages/frontend/package.json packages/frontend/package.json
-COPY packages/types/package.json packages/types/package.json
 
-
-RUN yarn --silent --frozen-lockfile --ignore-scripts
+RUN yarn --silent --frozen-lockfile --ignore-scripts install
+RUN yarn --silent --frozen-lockfile --ignore-scripts bootstrap
 
 COPY packages/types/ packages/types/
-RUN yarn bootstrap
+COPY tsconfig.json ./
+RUN yarn build:types
 
 COPY packages/backend/ packages/backend/
-COPY tsconfig.json ./
-
 RUN yarn build:backend
 
 ARG API_URL

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,13 @@ FROM node:14.17.3-alpine AS node-base
 RUN apk update && apk add gettext
 RUN wget -q -O- https://gobinaries.com/tj/node-prune | sh
 
+RUN yarn config set network-timeout 300000
 
 FROM node-base AS nginx-server
-
 RUN apk add nginx && rm -rf /var/cache/apk/*
 
 
 FROM node-base AS builder
-
 WORKDIR /app
 
 COPY ["package.json", "yarn.lock", "lerna.json", "./"]

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   "scripts": {
     "prepare": "husky install",
     "bootstrap": "lerna bootstrap",
+    "build:types": "yarn workspace @cyfm/types build",
     "build:frontend": "yarn workspace @cyfm/frontend build",
     "build:backend": "yarn workspace @cyfm/backend build",
     "start:frontend": "yarn workspace @cyfm/frontend start",
-    "start:backend": "yarn workspace @cyfm/backend start"
+    "start:prod": "yarn workspace @cyfm/backend start:prod"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/packages/frontend/craco.config.js
+++ b/packages/frontend/craco.config.js
@@ -15,6 +15,16 @@ module.exports = {
       plugin: CracoEsbuildPlugin,
       options: {
         enableSvgr: true,
+        esbuildLoaderOptions: {
+          loader: 'tsx',
+          target: 'es2015',
+        },
+        esbuildJestOptions: {
+          loaders: {
+            '.ts': 'ts',
+            '.tsx': 'tsx',
+          },
+        },
       },
     },
     {

--- a/packages/frontend/craco.config.js
+++ b/packages/frontend/craco.config.js
@@ -1,5 +1,6 @@
 const TerserPlugin = require('terser-webpack-plugin');
 const WorkerPlugin = require('worker-plugin');
+const CracoEsbuildPlugin = require('craco-esbuild');
 
 const isTerserPlugin = plugin => {
   return (
@@ -10,6 +11,12 @@ const isTerserPlugin = plugin => {
 
 module.exports = {
   plugins: [
+    {
+      plugin: CracoEsbuildPlugin,
+      options: {
+        enableSvgr: true,
+      },
+    },
     {
       plugin: {
         overrideWebpackConfig: ({

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -53,6 +53,7 @@
     "@types/react-modal": "^3.13.1",
     "@types/react-router-dom": "^5.3.2",
     "@typescript-eslint/visitor-keys": "^5.2.0",
+    "craco-esbuild": "^0.4.2",
     "eslint-config-react-app": "^6.0.0",
     "terser-webpack-plugin": "4.x",
     "typescript": "^4.1.2",

--- a/packages/frontend/src/components/Modal/GuideModal.tsx
+++ b/packages/frontend/src/components/Modal/GuideModal.tsx
@@ -4,8 +4,6 @@ import { nanoid } from 'nanoid';
 
 import styled from '@cyfm/styled';
 
-import Button from './ModalButton';
-
 import GUIDELINES from './GuidelineCase';
 
 import Button from './ModalButton';

--- a/packages/frontend/src/components/Modal/ModalType.ts
+++ b/packages/frontend/src/components/Modal/ModalType.ts
@@ -1,3 +1,5 @@
+import type React from 'react';
+
 export type ActionPayload = {
   target: string;
 };

--- a/packages/frontend/src/pages/EditorPage/index.tsx
+++ b/packages/frontend/src/pages/EditorPage/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import syncWorkerUrl from 'worker-plugin/loader?sharedWorker!./sync.worker';
 import styled from '@cyfm/styled';

--- a/packages/frontend/src/pages/IntroPage/index.tsx
+++ b/packages/frontend/src/pages/IntroPage/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { nanoid } from 'nanoid';

--- a/packages/frontend/src/pages/WriteEditorPage/index.tsx
+++ b/packages/frontend/src/pages/WriteEditorPage/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 
 import styled from '@cyfm/styled';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,7 +83,7 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/core@^7.8.4":
+"@babel/core@^7.12.17", "@babel/core@^7.8.4":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.0.tgz#c4ff44046f5fe310525cc9eb4ef5147f0c5374d4"
   integrity sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==
@@ -906,7 +906,7 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-commonjs@^7.12.1", "@babel/plugin-transform-modules-commonjs@^7.16.0":
+"@babel/plugin-transform-modules-commonjs@^7.12.1", "@babel/plugin-transform-modules-commonjs@^7.12.13", "@babel/plugin-transform-modules-commonjs@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.0.tgz#add58e638c8ddc4875bd9a9ecb5c594613f6c922"
   integrity sha512-Dzi+NWqyEotgzk/sb7kgQPJQf7AJkQBWsVp1N6JWc1lBVo0vkElUnGdr1PzUBmfsCCN5OOFya3RtpeHk15oLKQ==
@@ -2768,7 +2768,7 @@
     deepmerge "^4.2.2"
     svgo "^1.2.2"
 
-"@svgr/webpack@5.5.0":
+"@svgr/webpack@5.5.0", "@svgr/webpack@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@svgr/webpack/-/webpack-5.5.0.tgz#aae858ee579f5fa8ce6c3166ef56c6a1b381b640"
   integrity sha512-DOBOK255wfQxguUta2INKkzPj6AIS6iafZYiYmHn6W3pHlycSRRlvWKCfLDG10fXfLWqE3DJHgRUOyJYmARa7g==
@@ -5605,6 +5605,15 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+craco-esbuild@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/craco-esbuild/-/craco-esbuild-0.4.2.tgz#397c9bff896a0984b0b478888d85e17e548e2c05"
+  integrity sha512-j43UhZqVv1GuwQYAfWgPd7TvP3M8QGMP8C/zewtQ7oQVK/e5nLx2JiE8xWtMPiCmAtDux6IWD38S8NcLm/orPw==
+  dependencies:
+    "@svgr/webpack" "^5.5.0"
+    esbuild-jest "0.5.0"
+    esbuild-loader "^2.15.1"
+
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
@@ -6705,6 +6714,136 @@ es6-weak-map@^2.0.3:
     es5-ext "^0.10.46"
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.1"
+
+esbuild-android-arm64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz#3fc3ff0bab76fe35dd237476b5d2b32bb20a3d44"
+  integrity sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==
+
+esbuild-darwin-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz#8e9169c16baf444eacec60d09b24d11b255a8e72"
+  integrity sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==
+
+esbuild-darwin-arm64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz#1b07f893b632114f805e188ddfca41b2b778229a"
+  integrity sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==
+
+esbuild-freebsd-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz#0b8b7eca1690c8ec94c75680c38c07269c1f4a85"
+  integrity sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==
+
+esbuild-freebsd-arm64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz#2e1a6c696bfdcd20a99578b76350b41db1934e52"
+  integrity sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==
+
+esbuild-jest@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/esbuild-jest/-/esbuild-jest-0.5.0.tgz#7a9964bfdecafca3b675a8aeb08193bcdba8b9d7"
+  integrity sha512-AMZZCdEpXfNVOIDvURlqYyHwC8qC1/BFjgsrOiSL1eyiIArVtHL8YAC83Shhn16cYYoAWEW17yZn0W/RJKJKHQ==
+  dependencies:
+    "@babel/core" "^7.12.17"
+    "@babel/plugin-transform-modules-commonjs" "^7.12.13"
+    babel-jest "^26.6.3"
+
+esbuild-linux-32@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz#6fd39f36fc66dd45b6b5f515728c7bbebc342a69"
+  integrity sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==
+
+esbuild-linux-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz#9cb8e4bcd7574e67946e4ee5f1f1e12386bb6dd3"
+  integrity sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==
+
+esbuild-linux-arm64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz#3891aa3704ec579a1b92d2a586122e5b6a2bfba1"
+  integrity sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==
+
+esbuild-linux-arm@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz#8a00e99e6a0c6c9a6b7f334841364d8a2b4aecfe"
+  integrity sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==
+
+esbuild-linux-mips64le@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz#36b07cc47c3d21e48db3bb1f4d9ef8f46aead4f7"
+  integrity sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==
+
+esbuild-linux-ppc64le@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz#f7e6bba40b9a11eb9dcae5b01550ea04670edad2"
+  integrity sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==
+
+esbuild-loader@^2.15.1:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/esbuild-loader/-/esbuild-loader-2.16.0.tgz#a44a57a77ed2810d6b278579271f77d739aa7bc9"
+  integrity sha512-LCJEwkf+nMJbNmVYNgg/0PaIZDdr5OcHw1qbWAZLkrmBRX+KwHY/yAS6ia98UBtwzk/WhsftUBNB6tfPHgFIxw==
+  dependencies:
+    esbuild "^0.13.4"
+    joycon "^3.0.1"
+    json5 "^2.2.0"
+    loader-utils "^2.0.0"
+    tapable "^2.2.0"
+    type-fest "^1.4.0"
+    webpack-sources "^2.2.0"
+
+esbuild-netbsd-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz#a2fedc549c2b629d580a732d840712b08d440038"
+  integrity sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==
+
+esbuild-openbsd-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz#b22c0e5806d3a1fbf0325872037f885306b05cd7"
+  integrity sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==
+
+esbuild-sunos-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz#d0b6454a88375ee8d3964daeff55c85c91c7cef4"
+  integrity sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==
+
+esbuild-windows-32@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz#c96d0b9bbb52f3303322582ef8e4847c5ad375a7"
+  integrity sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==
+
+esbuild-windows-64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz#1f79cb9b1e1bb02fb25cd414cb90d4ea2892c294"
+  integrity sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==
+
+esbuild-windows-arm64@0.13.15:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz#482173070810df22a752c686509c370c3be3b3c3"
+  integrity sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==
+
+esbuild@^0.13.4:
+  version "0.13.15"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.13.15.tgz#db56a88166ee373f87dbb2d8798ff449e0450cdf"
+  integrity sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==
+  optionalDependencies:
+    esbuild-android-arm64 "0.13.15"
+    esbuild-darwin-64 "0.13.15"
+    esbuild-darwin-arm64 "0.13.15"
+    esbuild-freebsd-64 "0.13.15"
+    esbuild-freebsd-arm64 "0.13.15"
+    esbuild-linux-32 "0.13.15"
+    esbuild-linux-64 "0.13.15"
+    esbuild-linux-arm "0.13.15"
+    esbuild-linux-arm64 "0.13.15"
+    esbuild-linux-mips64le "0.13.15"
+    esbuild-linux-ppc64le "0.13.15"
+    esbuild-netbsd-64 "0.13.15"
+    esbuild-openbsd-64 "0.13.15"
+    esbuild-sunos-64 "0.13.15"
+    esbuild-windows-32 "0.13.15"
+    esbuild-windows-64 "0.13.15"
+    esbuild-windows-arm64 "0.13.15"
 
 escalade@^3.0.2, escalade@^3.1.1:
   version "3.1.1"
@@ -9564,6 +9703,11 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
+joycon@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.0.tgz#33bb2b6b5a6849a1e251bed623bdf610f477d49f"
+  integrity sha512-5Y/YJghKF/IzaUXTut0JtbQyHfBShTaIsH7hHhGXEzYO07zWdWZm5hr3Q6miqhrwsRqqm3mgOnUEZdn+1aRxKQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -9684,7 +9828,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.2:
+json5@^2.1.2, json5@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
@@ -14247,7 +14391,7 @@ sort-keys@^4.0.0:
   dependencies:
     is-plain-obj "^2.0.0"
 
-source-list-map@^2.0.0:
+source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
@@ -14796,6 +14940,11 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
+
 tar-pack@3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
@@ -15275,6 +15424,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
@@ -15863,6 +16017,14 @@ webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-sources@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.3.1.tgz#570de0af163949fe272233c2cefe1b56f74511fd"
+  integrity sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
 
 webpack@4.44.2:
   version "4.44.2"


### PR DESCRIPTION
## 변경 사항
`time docker build --no-cache` 결과
| 전 | 후 |
|---|---|
| ![image](https://user-images.githubusercontent.com/9497404/144058080-c2c72a8b-5c0b-4dfa-9fed-21ccdbea998d.png) | ![image](https://user-images.githubusercontent.com/9497404/144058119-02da18fc-d6e8-434c-9657-5542410c7dfc.png) |

- `@cyfm/types` 모듈이 빌드되지 않아 찾지 못하는 문제 수정 
- 프론트엔드 빌드에 esbuild 적용 (백엔드는 데코레이터 사용으로 인하여 적용 불가)

## 참고
- https://esbuild.github.io/
- https://www.npmjs.com/package/craco-esbuild
- https://stackoverflow.com/q/52135815