### PR TITLE
chore: 소켓 스트레스 테스트

### DIFF
--- a/packages/frontend/stressTest/loadTest.js
+++ b/packages/frontend/stressTest/loadTest.js
@@ -1,0 +1,62 @@
+const { io } = require('socket.io-client');
+
+const URL = process.env.REACT_APP_API_URL;
+const MAX_CLIENTS = 1000;
+const POLLING_PERCENTAGE = 0.05;
+const CLIENT_CREATION_INTERVAL_IN_MS = 10;
+const EMIT_INTERVAL_IN_MS = 1000;
+
+let clientCount = 0;
+let lastReport = new Date().getTime();
+let packetsSinceLastReport = 0;
+
+const createClient = () => {
+  const socket = io(URL, { withCredentials: true });
+
+  setInterval(() => {
+    socket.emit('submit', {
+      code: `function iterate(numArr) {
+            let result = [];
+            numArr.last = 'endPoint';
+            for (let i of numArr) {
+              result.push(i);
+            }
+            return result;
+          }`,
+      problemId: '618a3c998e94a96a2e45efe2',
+      id: ['iVt7d9yNO5RQCaUyR3m2g', 'zJfif2adhRvug7nOkfmhf'],
+    });
+  }, EMIT_INTERVAL_IN_MS);
+
+  socket.on('testSuccess', ({ id, resultCode }) => {
+    packetsSinceLastReport++;
+    console.log('success', id, resultCode);
+  });
+
+  socket.on('disconnect', reason => {
+    console.log(`disconnect due to ${reason}`);
+  });
+
+  if (++clientCount < MAX_CLIENTS) {
+    setTimeout(createClient, CLIENT_CREATION_INTERVAL_IN_MS);
+  }
+};
+
+createClient();
+
+const printReport = () => {
+  const now = new Date().getTime();
+  const durationSinceLastReport = (now - lastReport) / 1000;
+  const packetsPerSeconds = (
+    packetsSinceLastReport / durationSinceLastReport
+  ).toFixed(2);
+
+  console.log(
+    `client count: ${clientCount} ; average packets received per second: ${packetsPerSeconds}`,
+  );
+
+  packetsSinceLastReport = 0;
+  lastReport = now;
+};
+
+setInterval(printReport, 5000);


### PR DESCRIPTION
## 소켓 요청만 테스트한 경우(100명이 1초에 한번씩 요청)
![image](https://user-images.githubusercontent.com/67806982/144232257-50c713f8-159b-46ca-9025-9539d59664e8.png)


## dev 서버채점까지 테스트 진행(1000명이 1초에 한번씩 요청)
![image](https://user-images.githubusercontent.com/67806982/144232364-867a5892-b267-41d5-affa-15456188609b.png)


## 메인 배포 서버 채점까지 테스트(최대 3명이 3초에 한번씩 제출)
![image](https://user-images.githubusercontent.com/67806982/144232426-79b29a89-2909-4038-aed8-7e674a7356b8.png)
![image](https://user-images.githubusercontent.com/67806982/144232514-ba23530d-a513-4b4e-a19e-104e7b70446a.png)


## 이슈
- 서버 채점까지 테스트한 경우 로그인 과정을 건너뛰고 테스트하였음(소켓에서 세션 넣어준 다음 실제처럼 실행되는 것은 실패)
- 소켓에 세션아이디 담아서 보내는 것이 안되었다.