### PR TITLE
feat: 타임아웃 이벤트 추가 및 에러 이벤트 전달 문제 수정

### DIFF
--- a/packages/frontend/src/hooks/useSandbox/debug.ts
+++ b/packages/frontend/src/hooks/useSandbox/debug.ts
@@ -85,6 +85,9 @@ export function execCodeWithSandbox(options: ISandboxOptions) {
           break;
         case 'error':
           dispatcher.dispatchEvent(
+            new CustomEvent('error', { detail: data.payload }),
+          );
+          dispatcher.dispatchEvent(
             new CustomEvent('stderr', { detail: data.payload }),
           );
           break;

--- a/packages/frontend/src/hooks/useSandbox/index.ts
+++ b/packages/frontend/src/hooks/useSandbox/index.ts
@@ -13,6 +13,7 @@ interface ISandboxHookOptions extends ISandboxOptions {
   onInit?: (event: CustomEvent) => void;
   onExit?: (event: CustomEvent) => void;
   onError?: (event: CustomEvent) => void;
+  onTimeout?: (event: CustomEvent) => void;
   onLoadStart?: (event: CustomEvent) => void;
   onLoadEnd?: (event: CustomEvent) => void;
   timeout?: number;
@@ -34,6 +35,7 @@ export function useSandbox(
     onInit: () => {},
     onExit: () => {},
     onError: () => {},
+    onTimeout: () => {},
     onLoadStart: () => {},
     onLoadEnd: () => {},
     timeout: 0,
@@ -79,9 +81,6 @@ export function useSandbox(
     const onExit = (options.onExit ??
       (event => {
         const customEvent = event as CustomEvent;
-        if (parseInt(customEvent.detail, 10) === SIGKILL) {
-          console.log(`TimeoutError: timeout`);
-        }
         console.log(`[EXIT CODE: ${customEvent.detail || -1}]`);
 
         // 재시작
@@ -105,6 +104,12 @@ export function useSandbox(
     const onError = (options.onError ?? (() => {})) as EventListener;
     sandboxRef.current.addEventListener('error', onError);
 
+    const onTimeout = (options.onTimeout ??
+      (() => {
+        console.error(`TimeoutError: timeout`);
+      })) as EventListener;
+    sandboxRef.current.addEventListener('timeout', onTimeout);
+
     let timeoutTimer: NodeJS.Timer | number = INIT_TIMER_ID;
     let delayTimer: NodeJS.Timer | number = INIT_TIMER_ID;
     const onExec = (event => {
@@ -112,6 +117,7 @@ export function useSandbox(
         clearTimeout(timeoutTimer as number);
         timeoutTimer = INIT_TIMER_ID;
         timeoutTimer = setTimeout(() => {
+          sandboxRef.current?.dispatchEvent(new CustomEvent('timeout'));
           sandboxRef.current?.dispatchEvent(
             new CustomEvent('kill', { detail: SIGKILL }),
           );
@@ -141,6 +147,7 @@ export function useSandbox(
       sandboxRef.current?.removeEventListener('init', onInit);
       sandboxRef.current?.removeEventListener('exit', onExit);
       sandboxRef.current?.removeEventListener('error', onError);
+      sandboxRef.current?.removeEventListener('timeout', onTimeout);
       sandboxRef.current?.removeEventListener('stdout', onOutput);
       sandboxRef.current?.removeEventListener('stderr', onOutputError);
       sandboxRef.current?.removeEventListener('exec', onExec);

--- a/packages/frontend/src/hooks/useSandbox/index.ts
+++ b/packages/frontend/src/hooks/useSandbox/index.ts
@@ -12,6 +12,7 @@ interface ISandboxHookOptions extends ISandboxOptions {
   setter: React.Dispatch<React.SetStateAction<string>>;
   onInit?: (event: CustomEvent) => void;
   onExit?: (event: CustomEvent) => void;
+  onError?: (event: CustomEvent) => void;
   onLoadStart?: (event: CustomEvent) => void;
   onLoadEnd?: (event: CustomEvent) => void;
   timeout?: number;
@@ -32,6 +33,7 @@ export function useSandbox(
     setter: () => {},
     onInit: () => {},
     onExit: () => {},
+    onError: () => {},
     onLoadStart: () => {},
     onLoadEnd: () => {},
     timeout: 0,
@@ -94,11 +96,14 @@ export function useSandbox(
     }) as EventListener;
 
     const onOutputError = (event => {
-      console.log((event as CustomEvent).detail);
+      console.error((event as CustomEvent).detail);
     }) as EventListener;
 
     sandboxRef.current.addEventListener('stdout', onOutput);
     sandboxRef.current.addEventListener('stderr', onOutputError);
+
+    const onError = (options.onError ?? (() => {})) as EventListener;
+    sandboxRef.current.addEventListener('error', onError);
 
     let timeoutTimer: NodeJS.Timer | number = INIT_TIMER_ID;
     let delayTimer: NodeJS.Timer | number = INIT_TIMER_ID;
@@ -135,6 +140,7 @@ export function useSandbox(
     return () => {
       sandboxRef.current?.removeEventListener('init', onInit);
       sandboxRef.current?.removeEventListener('exit', onExit);
+      sandboxRef.current?.removeEventListener('error', onError);
       sandboxRef.current?.removeEventListener('stdout', onOutput);
       sandboxRef.current?.removeEventListener('stderr', onOutputError);
       sandboxRef.current?.removeEventListener('exec', onExec);


### PR DESCRIPTION
## 변경 사항
- `timeout` 이벤트 추가
- `error` 이벤트가 `dispatcher`를 통해 전달이 되지 않는 문제 수정
- `onError`, `onTimeout` 콜백 옵션 추가