### PR TITLE
fix: 결과 페이지 로그아웃 시 데이터가 들어가는 버그 및 에러 핸들링

### DIFF
--- a/packages/frontend/src/pages/IntroPage/index.tsx
+++ b/packages/frontend/src/pages/IntroPage/index.tsx
@@ -318,7 +318,7 @@ const IntroPage = () => {
       </MainTitleWrapper>
       <MainTextWrapper>
         {INTRO_MESSAGE.split('\n').map(message => (
-          <MessageWrapper>{message}</MessageWrapper>
+          <MessageWrapper key={nanoid()}>{message}</MessageWrapper>
         ))}
         <TitleWrapper>
           코딩은 직접 부딪히고 경험해야 실력이 향상 된다고 합니다!

--- a/packages/frontend/src/pages/ResultPage/message.ts
+++ b/packages/frontend/src/pages/ResultPage/message.ts
@@ -1,0 +1,1 @@
+export const TEST_FAIL_MESSAGE = `채점 과정에서 오류가\n발생했습니다.\n담당자에게 문의 바랍니다.`;

--- a/packages/frontend/src/pages/ResultPage/reducer.ts
+++ b/packages/frontend/src/pages/ResultPage/reducer.ts
@@ -1,0 +1,36 @@
+type ModalState = {
+    message: string;
+    openMessage: boolean;
+  };
+  
+  type ActionPayload = {
+    target: string;
+  };
+  
+  type OpenAction = {
+    type: 'open';
+    payload: ActionPayload;
+  };
+  
+  type CloseAction = {
+    type: 'close';
+    payload: ActionPayload;
+  };
+  
+  type ModalReducerAction = OpenAction | CloseAction;
+  
+  const modalReducer = (
+    state: ModalState,
+    action: ModalReducerAction,
+  ): ModalState => {
+    const isOpen = action.type === 'open';
+    switch (action.payload.target) {
+      case 'message':
+        return { ...state, openMessage: isOpen };
+      default:
+        return state;
+    }
+  };
+  
+  export { modalReducer };
+  


### PR DESCRIPTION
**작업 목록**
- 결과 페이지에서 로그아웃 시 로그인 페이지로 리다이렉션
- 결과 페이지 에러 핸들링 추가
- 결과 페이지에서 문제 다시 풀기 및 문제 리스트로 가기 버튼 추가
- 소개 페이지에서 메세지 리스트에 누락된 `key` props 추가