### PR TITLE
chore: 레이아웃 관련 문제 수정

### DIFF
--- a/packages/frontend/src/components/FullWidthViewer/styles.module.css
+++ b/packages/frontend/src/components/FullWidthViewer/styles.module.css
@@ -1,5 +1,4 @@
 .fullWidthViewer {
   width: 100%;
-  background-color: #2f333c;
   padding: 15px;
 }

--- a/packages/frontend/src/pages/DebugPage/index.tsx
+++ b/packages/frontend/src/pages/DebugPage/index.tsx
@@ -45,8 +45,9 @@ import {
 
 const ViewerWrapper = styled.div`
   display: flex;
-  flex-basis: 50%;
   width: 100%;
+  height: 100%;
+  background-color: #2f333c;
   overflow-y: auto;
 `;
 
@@ -56,8 +57,7 @@ const EditorWrapper = styled.div`
 
 const ConsoleWrapper = styled.div`
   padding: 20px;
-  height: 100%;
-  flex-basis: 50%;
+  min-height: 300px;
   background: #24262a;
   color: white;
 `;

--- a/packages/frontend/src/pages/EditorPage/index.tsx
+++ b/packages/frontend/src/pages/EditorPage/index.tsx
@@ -9,7 +9,7 @@ const controllerWidth = 5;
 const FlexWrapper = styled.div`
   display: flex;
   width: 100%;
-  min-height: calc(100vh - 80px);
+  height: calc(100vh - 80px);
 `;
 
 const ColumnWrapper = styled.div`

--- a/packages/frontend/src/pages/EditorPage/index.tsx
+++ b/packages/frontend/src/pages/EditorPage/index.tsx
@@ -8,7 +8,7 @@ const controllerWidth = 5;
 
 const FlexWrapper = styled.div`
   display: flex;
-  min-width: 100vw;
+  width: 100%;
   min-height: calc(100vh - 80px);
 `;
 

--- a/packages/frontend/src/pages/WritePage/index.tsx
+++ b/packages/frontend/src/pages/WritePage/index.tsx
@@ -117,8 +117,7 @@ const TagButton = styled(Button)`
 
 const ConsoleWrapper = styled.div`
   padding: 20px;
-  height: 100%;
-  flex-basis: 50%;
+  min-height: 300px;
   background: #24262a;
   color: white;
 `;
@@ -431,7 +430,7 @@ const WritePage = () => {
               />
               <Editor
                 previewStyle="vertical"
-                height="60%"
+                height="100%"
                 initialEditType="wysiwyg"
                 hideModeSwitch
                 placeholder="마크다운 문법에 맞춰 값을 입력해주세요."


### PR DESCRIPTION
![Screen Shot 2021-12-05 at 2 09 26 AM](https://user-images.githubusercontent.com/9497404/144719032-2c38ed01-00a0-4242-904c-e48cd4d42cc6.png)

## 변경 사항
- 윈도우 환경에서 가로스크롤이 나타나는 현상 수정
- 콘텐츠 길이가 긴 경우, 마크다운 에디터의 배경색이 콘텐츠 높이에 맞게 적용되지 않는 현상 수정
