### PR TITLE
chore: 마크다운 에디터가 의도한대로 동작하지 않는 문제를 수정

### DIFF
--- a/packages/frontend/src/pages/WritePage/index.tsx
+++ b/packages/frontend/src/pages/WritePage/index.tsx
@@ -430,10 +430,10 @@ const WritePage = () => {
                 placeholder="제목을 입력해주세요"
               />
               <Editor
-                previewStyle="vertical"
-                height="60%"
-                initialEditType="wysiwyg"
+                previewStyle="tab"
                 hideModeSwitch
+                height="100%"
+                initialEditType="markdown"
                 placeholder="마크다운 문법에 맞춰 값을 입력해주세요."
                 theme="dark"
                 usageStatistics={false}


### PR DESCRIPTION
## 동작 화면

![Dec-05-2021 05-34-46](https://user-images.githubusercontent.com/9497404/144723962-3300422b-40fd-44d1-82f3-b7c801dda744.gif)

## 변경 사항
- 에디터의 기본 타입을 `markdown`으로 변경
- preview를 활성화